### PR TITLE
Remove stranded high-bridge sections after nearby collapses

### DIFF
--- a/src/map/bridge_rim_tiles.rs
+++ b/src/map/bridge_rim_tiles.rs
@@ -1,0 +1,79 @@
+//! Theater identity used by native high-bridge edge cleanup, 576770/576200.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HighBridgeRimTiles {
+    pub base: i32,
+    pub top_left: [i32; 2],
+    pub bottom_right: [i32; 2],
+    pub top_right: [i32; 2],
+    pub bottom_left: [i32; 2],
+    pub middle: [i32; 2],
+}
+
+impl HighBridgeRimTiles {
+    /// Original ReadTheater545150 reads these ten signed keys independently.
+    /// Their values are BridgeSet-relative tile identities, not TileSet indices.
+    pub(crate) fn from_theater(theater: &super::theater::TheaterData) -> Self {
+        let base = theater
+            .bridge_set
+            .and_then(|set| theater.lookup.bounds().get(usize::from(set)))
+            .map_or(-1, |bounds| i32::from(bounds.start));
+        Self::from_ini(base, &theater.ini_data)
+    }
+
+    pub(crate) fn from_ini(base: i32, bytes: &[u8]) -> Self {
+        let ini = crate::rules::ini_parser::IniFile::from_bytes(bytes).ok();
+        let general = ini.as_ref().and_then(|ini| ini.section("General"));
+        // These native globals are signed ReadInteger results. The older
+        // presentation-facing Option<u16> fields lose negative/large keys.
+        let value = |key| general.map_or(-1, |section| section.read_int(key, -1));
+        Self {
+            base,
+            top_left: [value("BridgeTopLeft1"), value("BridgeTopLeft2")],
+            bottom_right: [value("BridgeBottomRight1"), value("BridgeBottomRight2")],
+            top_right: [value("BridgeTopRight1"), value("BridgeTopRight2")],
+            bottom_left: [value("BridgeBottomLeft1"), value("BridgeBottomLeft2")],
+            middle: [value("BridgeMiddle1"), value("BridgeMiddle2")],
+        }
+    }
+
+    fn relative(self, tile: i32) -> i32 {
+        tile.wrapping_sub(self.base).wrapping_add(1)
+    }
+
+    fn middle_matches(self, relative: i32, axis: usize) -> bool {
+        (0..4).any(|variant| relative == self.middle[axis].wrapping_add(variant))
+    }
+
+    /// Direction of the edge search dispatched by 576770. Preserve the native
+    /// first-match order, including aliased theater keys.
+    pub(crate) fn start_direction(self, tile: i32, subtile: u8) -> Option<u8> {
+        let relative = self.relative(tile);
+        if (subtile == 8 && self.top_left.contains(&relative))
+            || (subtile == 5 && self.middle_matches(relative, 0))
+        {
+            Some(2)
+        } else if (subtile == 12 && self.top_right.contains(&relative))
+            || (subtile == 7 && self.middle_matches(relative, 1))
+        {
+            Some(4)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn is_end(self, tile: i32, subtile: u8, direction: u8) -> bool {
+        let relative = self.relative(tile);
+        match direction {
+            2 => {
+                subtile == 4
+                    && (self.bottom_right.contains(&relative) || self.middle_matches(relative, 0))
+            }
+            4 => {
+                subtile == 2
+                    && (self.bottom_left.contains(&relative) || self.middle_matches(relative, 1))
+            }
+            _ => false,
+        }
+    }
+}

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -18,6 +18,7 @@ pub mod actions;
 pub(crate) mod authored_overlay;
 pub mod basic;
 pub mod bridge_facts;
+pub(crate) mod bridge_rim_tiles;
 pub mod cell_index;
 pub(crate) mod construction_trace;
 pub mod scenario_menu;

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -1544,6 +1544,8 @@ pub struct ResolvedTerrainGrid {
     tile_registry_len: Option<usize>,
     /// First flat tile id of the active theater's concrete high-bridge set.
     bridge_set_start: Option<u16>,
+    /// Immutable signed ReadTheater545150 identities for high-rim selection.
+    high_bridge_rim_tiles: Option<super::bridge_rim_tiles::HighBridgeRimTiles>,
     /// First flat tile id of the active theater's wooden high-bridge set.
     wood_bridge_set_start: Option<u16>,
     /// Terrain animations the load resolved, in the native anti-diagonal cell
@@ -1624,6 +1626,7 @@ impl ResolvedTerrainGrid {
             projectile_water_set_base: -1,
             tile_registry_len: None,
             bridge_set_start: None,
+            high_bridge_rim_tiles: None,
             wood_bridge_set_start: None,
             tile_animations: Vec::new(),
             destroyable_cliff_catalog: None,
@@ -1706,6 +1709,18 @@ impl ResolvedTerrainGrid {
 
     pub(crate) fn concrete_bridge_set_base(&self) -> i32 {
         self.bridge_set_start.map_or(-1, i32::from)
+    }
+
+    pub(crate) fn high_bridge_rim_tiles(&self) -> Option<super::bridge_rim_tiles::HighBridgeRimTiles> {
+        self.high_bridge_rim_tiles
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_set_high_bridge_rim_tiles(
+        &mut self,
+        tiles: super::bridge_rim_tiles::HighBridgeRimTiles,
+    ) {
+        self.high_bridge_rim_tiles = Some(tiles);
     }
 
     pub(crate) fn shared_cell_dummy(&self) -> SharedCellDummy {
@@ -3545,6 +3560,8 @@ impl ResolvedTerrainGrid {
                     .and_then(|td| td.rmg_tiles.water_set)
                     .map_or(-1, i32::from),
                 tile_registry_len: theater_data.map(|td| td.lookup.len()),
+                high_bridge_rim_tiles: theater_data
+                    .map(super::bridge_rim_tiles::HighBridgeRimTiles::from_theater),
                 bridge_set_start: theater_data.and_then(|td| {
                     td.bridge_set
                         .and_then(|set| td.lookup.bounds().get(set as usize))
@@ -4327,6 +4344,8 @@ impl ResolvedTerrainGrid {
                 .and_then(|td| td.rmg_tiles.water_set)
                 .map_or(-1, i32::from),
             tile_registry_len: theater_data.map(|td| td.lookup.len()),
+            high_bridge_rim_tiles: theater_data
+                .map(super::bridge_rim_tiles::HighBridgeRimTiles::from_theater),
             bridge_set_start: theater_data.and_then(|td| {
                 td.bridge_set
                     .and_then(|set| td.lookup.bounds().get(set as usize))

--- a/src/sim/bridge_specs.rs
+++ b/src/sim/bridge_specs.rs
@@ -852,8 +852,11 @@ fn update_ramp_perpendicular_recursive(
 /// - **DamageB**: progress Variant0 → Variant1 and Variant1 → Damaged;
 ///   no-op on Damaged and AboutToFall.
 /// - **CollapseA / CollapseB**: advance Variant0 / Variant1 / Damaged to
-///   Damaged; preserve AboutToFall (the recursive `+3 → +3` write in the
-///   reference is a no-op semantically).
+///   Damaged; preserve AboutToFall in this legacy projection. Native572440
+///   normalizes tile-base+1, so its absolute base+Middle+3 terminal write
+///   produces relative Middle+4, outside the four-class model. Full56EB80
+///   tile/level/subtile delivery remains open; this is not a native no-op.
+///   The former `+3 → +3` interpretation omitted that +1 normalization.
 pub(crate) fn apply_anchor_class_transition(
     current: crate::sim::bridge_state::BridgeheadAnchorClass,
     phase: Phase,

--- a/src/sim/bridge_state/mod.rs
+++ b/src/sim/bridge_state/mod.rs
@@ -41,6 +41,7 @@ mod damaged_variant;
 mod record_scan;
 pub(crate) mod gap_restamp;
 pub(crate) mod publication;
+pub(crate) mod rim;
 
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};

--- a/src/sim/bridge_state/rim.rs
+++ b/src/sim/bridge_state/rim.rs
@@ -1,0 +1,214 @@
+//! Native high bridge cleanup control flow (576770 -> 576200).
+//!
+//! The host owns live cells and executes group writes/callbacks synchronously.
+//! No precomputed mutation list may stand in for callback-time state here.
+//! Evidence: HIGH_BRIDGE_RIM_REFRESH_ALGORITHM_GHIDRA_REPORT.md and
+//! tools/spatial_oracle/bridge_rim. The current stock corpus covers one axis;
+//! additional selector branches require their own comparisons.
+
+use crate::map::bridge_rim_tiles::HighBridgeRimTiles;
+
+#[cfg(test)]
+#[path = "rim_tests.rs"]
+mod tests;
+
+pub(crate) type RimCoord = (i16, i16);
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RimCell {
+    pub coord: RimCoord,
+    pub flags: u32,
+    pub tile: i32,
+    pub subtile: u8,
+    /// Native +2C target's current +24 coordinate, required only when the
+    /// structural bit is set without the anchor-self bit.
+    pub anchor: Option<RimCoord>,
+}
+
+pub(crate) trait HighBridgeRimHost {
+    /// Stable real-cell identity or the one shared dummy identity.
+    type Cell: Copy;
+    fn tiles(&self) -> HighBridgeRimTiles;
+    fn map_size(&self) -> (i32, i32);
+    /// Same fixed-stride lookup and retained dummy effects as Get_CellClass.
+    fn cell(&mut self, coord: RimCoord) -> Self::Cell;
+    /// Read a retained object without another Get_CellClass/dummy stamp.
+    fn read(&self, cell: Self::Cell) -> RimCell;
+    /// The selector separately probes Map+13C after its Size-diamond guard.
+    fn allocated(&self, coord: RimCoord) -> bool;
+    /// Execute full 47E040, including each slot's writes BEFORE its fallout.
+    fn clear_group(&mut self, anchor: Self::Cell, direction: u8);
+    /// The caller's +11E=0/+44=-1 stores, followed by its extra radar mark.
+    fn clear_overlay_and_mark_radar(&mut self, cell: Self::Cell);
+    /// 575EE0 remains observable even when this refresh makes no field writes.
+    fn notify_span(&mut self, first: RimCoord, end: RimCoord);
+    /// Dispatch event31 if the retained cell's current Tag pointer is nonnull.
+    fn notify_cell(&mut self, cell: Self::Cell);
+    /// Presentation invalidation for the searched span. It must not own cells.
+    fn mark_span(&mut self, start: RimCoord, end: RimCoord);
+    /// Begin a fresh native sentinel rectangle before this selector call.
+    fn reset_span_marks(&mut self);
+    /// Publish only when the accumulated rectangle differs from the sentinel.
+    fn mark_screen(&mut self);
+}
+
+pub(crate) fn step(coord: RimCoord, direction: u8) -> RimCoord {
+    let delta = crate::util::direction::DIRECTION_DELTAS[usize::from(direction & 7)];
+    (
+        coord.0.wrapping_add(delta.0 as i16),
+        coord.1.wrapping_add(delta.1 as i16),
+    )
+}
+
+/// Original 575EE0: ascending endpoint-exclusive span, each row in the order
+/// center, +1 perpendicular, -1 perpendicular, -2 perpendicular. The host must
+/// perform every lookup even without a CellTag: it may move the shared dummy.
+pub(crate) fn notify_span_cells(host: &mut impl HighBridgeRimHost, first: RimCoord, end: RimCoord) {
+    let horizontal = first.1 == end.1;
+    let reversed = if horizontal {
+        end.0 < first.0
+    } else {
+        end.1 < first.1
+    };
+    let (mut cursor, last) = if reversed { (end, first) } else { (first, end) };
+    while cursor != last {
+        let positive = if horizontal { 4 } else { 2 };
+        let negative = (positive + 4) & 7;
+        for coord in [cursor, step(cursor, positive)] {
+            let cell = host.cell(coord);
+            host.notify_cell(cell);
+        }
+        let third = host.cell(step(cursor, negative));
+        host.notify_cell(third);
+        // 576073/5761A3 use the third retained CellClass +24 AFTER its Tag
+        // callback. A real fixed-stride alias or a moved dummy matters here.
+        let fourth = host.cell(step(host.read(third).coord, negative));
+        host.notify_cell(fourth);
+        cursor = step(cursor, if horizontal { 2 } else { 4 });
+    }
+}
+
+/// Original 576770 selector. Direction-order neighbor reads and anchor
+/// resolution precede the independent theater scan; bridge roles are not input.
+pub(crate) fn update_adjacent(host: &mut impl HighBridgeRimHost, input: RimCoord) {
+    let Some(neighbor) = (0..8).find_map(|direction| {
+        let cell = host.cell(step(input, direction));
+        (host.read(cell).flags & 0x500 != 0).then_some(cell)
+    }) else {
+        return;
+    };
+
+    let initial = host.read(neighbor);
+    let mut cursor;
+    if initial.flags & 0x100 == 0 {
+        let forward = if initial.flags & 0x800 != 0 { 4 } else { 2 };
+        cursor = initial.coord;
+        let mut destroyed_count = 0;
+        loop {
+            cursor = step(cursor, forward);
+            let cell = host.cell(cursor);
+            if host.read(cell).flags & 0x400 == 0 {
+                break;
+            }
+            destroyed_count += 1;
+            if destroyed_count > 3 {
+                return;
+            }
+        }
+        let backward = (forward + 4) & 7;
+        cursor = step(step(cursor, backward), backward);
+    } else if initial.flags & 0x80 == 0 {
+        // A null/unrepresented native anchor cannot establish a valid target.
+        let Some(anchor) = initial.anchor else {
+            return;
+        };
+        cursor = anchor;
+    } else {
+        cursor = initial.coord;
+    }
+
+    let forward = if host.read(neighbor).flags & 0x800 != 0 {
+        6
+    } else {
+        0
+    };
+    host.reset_span_marks();
+    let (width, height) = host.map_size();
+    let tiles = host.tiles();
+    loop {
+        let (x, y) = (i32::from(cursor.0), i32::from(cursor.1));
+        if x + y <= width || width <= x - y || width <= y - x || width + height * 2 < x + y {
+            return;
+        }
+        if host.allocated(cursor) {
+            let cell = host.cell(cursor);
+            let fields = host.read(cell);
+            if let Some(direction) = tiles.start_direction(fields.tile, fields.subtile) {
+                if update_edge(host, cursor, direction) {
+                    host.mark_screen();
+                }
+                return;
+            }
+        }
+        cursor = step(cursor, forward);
+    }
+}
+
+/// Original 576200. Tail recursion restarts the complete search at the initial
+/// coordinate after every group clear. An iterative restart preserves that
+/// order without placing a native-length bound on Rust's call stack.
+pub(crate) fn update_edge(
+    host: &mut impl HighBridgeRimHost,
+    start: RimCoord,
+    direction: u8,
+) -> bool {
+    let mut changed = false;
+    'restart: loop {
+        let tiles = host.tiles();
+        let mut cell = host.cell(start);
+        let first = step(host.read(cell).coord, direction);
+        let mut found = None;
+        // Candidate distances1..29; distance30 is the original failure sentinel.
+        for distance in 1..30 {
+            let requested = step(host.read(cell).coord, direction);
+            cell = host.cell(requested);
+            let fields = host.read(cell);
+            if tiles.is_end(fields.tile, fields.subtile, direction) {
+                found = Some((requested, distance));
+                break;
+            }
+        }
+        let Some((end, distance)) = found else {
+            return changed;
+        };
+        cell = host.cell(start);
+        host.mark_span(start, end);
+        let mut previous_clear = false;
+        let mut last_anchor = (-1, -1);
+        let mut notified = false;
+        for _ in 0..distance {
+            let fields = host.read(cell);
+            let anchor = fields.flags & 0x80 != 0;
+            if anchor && previous_clear {
+                last_anchor = fields.coord;
+            }
+            if !anchor && !previous_clear && last_anchor != (-1, -1) {
+                let back = step(fields.coord, direction.wrapping_sub(4) & 7);
+                // This lookup is a native call before the setter itself.
+                let target = host.cell(back);
+                host.clear_group(target, if direction == 2 { 0 } else { 6 });
+                host.clear_overlay_and_mark_radar(target);
+                changed = true;
+                continue 'restart;
+            }
+            previous_clear = !anchor;
+            if previous_clear && !notified {
+                host.notify_span(first, end);
+                notified = true;
+            }
+            // Notifications may move the dummy. Resume the retained object.
+            cell = host.cell(step(host.read(cell).coord, direction));
+        }
+        return changed;
+    }
+}

--- a/src/sim/bridge_state/rim_tests.rs
+++ b/src/sim/bridge_state/rim_tests.rs
@@ -1,0 +1,348 @@
+//! Compare the Rust control flow with original 576770/576200 execution.
+//! The supplied host replaces object/radar/presentation effects with the same
+//! declared sinks as the native corpus. This is not world-integration coverage.
+
+use super::*;
+use crate::map::bridge_facts::{
+    BridgeAnchorRelation, BridgeCellFacts, BridgeFlagStamp, BridgeStampFamily, BridgeStampSlot,
+    apply_bridge_fact_slot,
+};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+
+#[derive(Clone)]
+struct SuppliedCell {
+    coord: RimCoord,
+    tile: i32,
+    subtile: u8,
+    facts: BridgeCellFacts,
+    // Native +2C is a pointer, not the derived self relation in BridgeCellFacts.
+    anchor: Option<RimCoord>,
+}
+
+impl SuppliedCell {
+    fn snapshot(&self) -> Value {
+        json!({"coord": self.coord, "flags": self.facts.raw_flags,
+            "overlay": self.facts.overlay_id.map_or(-1, i32::from),
+            "state": self.facts.state_byte, "anchor": self.anchor})
+    }
+}
+
+struct SuppliedHost {
+    tiles: HighBridgeRimTiles,
+    size: (i32, i32),
+    cells: BTreeMap<RimCoord, SuppliedCell>,
+    source_order: Vec<RimCoord>,
+    calls: Vec<Value>,
+    dummy: SuppliedCell,
+}
+
+#[derive(Clone, Copy)]
+enum SuppliedHandle {
+    Real(RimCoord),
+    Dummy,
+}
+
+fn coord(value: &Value) -> RimCoord {
+    serde_json::from_value(value.clone()).unwrap()
+}
+
+impl SuppliedHost {
+    fn stock() -> Self {
+        let input: Value = serde_json::from_str(include_str!(
+            "../../../tools/spatial_oracle/bridge_rim_stock_inputs.json"
+        ))
+        .unwrap();
+        Self::from_input(&input)
+    }
+
+    fn from_input(input: &Value) -> Self {
+        let mut ini = String::from("[General]\n");
+        for (key, value) in input["rim_keys"].as_object().unwrap() {
+            ini.push_str(&format!("{key}={value}\n"));
+        }
+        let mut host = Self {
+            tiles: HighBridgeRimTiles::from_ini(
+                input["bridge_base"].as_i64().unwrap() as i32,
+                ini.as_bytes(),
+            ),
+            size: serde_json::from_value(input["size"].clone()).unwrap(),
+            cells: BTreeMap::new(),
+            source_order: Vec::new(),
+            calls: Vec::new(),
+            dummy: SuppliedCell {
+                coord: (0, 0),
+                tile: -1,
+                subtile: 0,
+                facts: BridgeCellFacts::default(),
+                anchor: None,
+            },
+        };
+        for row in input["cells"].as_array().unwrap() {
+            let (x, y, tile, subtile, flags, overlay, state, anchor, _, _): (
+                i16,
+                i16,
+                i32,
+                u8,
+                u32,
+                Option<u8>,
+                u8,
+                Option<RimCoord>,
+                u8,
+                u8,
+            ) = serde_json::from_value(row.clone()).unwrap();
+            host.source_order.push((x, y));
+            host.cells.insert(
+                (x, y),
+                SuppliedCell {
+                    coord: (x, y),
+                    tile,
+                    subtile,
+                    facts: BridgeCellFacts {
+                        raw_flags: flags,
+                        state_byte: state,
+                        overlay_id: overlay,
+                        ..Default::default()
+                    },
+                    anchor: anchor.filter(|_| flags & 0x80 == 0),
+                },
+            );
+        }
+        host
+    }
+
+    fn canonical(coord: RimCoord) -> Option<RimCoord> {
+        let index = i32::from(coord.1) * 512 + i32::from(coord.0);
+        (0..0x40000)
+            .contains(&index)
+            .then_some(((index % 512) as i16, (index / 512) as i16))
+    }
+
+    fn get(&mut self, coord: RimCoord) -> &mut SuppliedCell {
+        if let Some(canonical) = Self::canonical(coord).filter(|c| self.cells.contains_key(c)) {
+            return self.cells.get_mut(&canonical).unwrap();
+        }
+        self.dummy.coord = coord;
+        &mut self.dummy
+    }
+
+    fn by_handle(&self, cell: SuppliedHandle) -> &SuppliedCell {
+        match cell {
+            SuppliedHandle::Real(coord) => &self.cells[&coord],
+            SuppliedHandle::Dummy => &self.dummy,
+        }
+    }
+
+    fn by_handle_mut(&mut self, cell: SuppliedHandle) -> &mut SuppliedCell {
+        match cell {
+            SuppliedHandle::Real(coord) => self.cells.get_mut(&coord).unwrap(),
+            SuppliedHandle::Dummy => &mut self.dummy,
+        }
+    }
+
+    fn snapshots(&self) -> Vec<Value> {
+        self.source_order
+            .iter()
+            .map(|coord| self.cells[coord].snapshot())
+            .collect()
+    }
+
+    fn collapse_input(&mut self, coord: RimCoord) {
+        let direction = if self.get(coord).facts.raw_flags & 0x800 != 0 {
+            0
+        } else {
+            6
+        };
+        let cell = self.cell(coord);
+        self.clear_group(cell, direction);
+        self.clear_overlay_and_mark_radar(cell);
+    }
+}
+
+#[test]
+fn retained_dummy_and_requested_endpoint_match_original_control_cases() {
+    let original: Value = serde_json::from_str(include_str!(
+        "../../../tools/spatial_oracle/bridge_rim_control.json"
+    ))
+    .unwrap();
+    for case in original["cases"].as_array().unwrap() {
+        let mut host = SuppliedHost::from_input(&case["input"]);
+        assert_eq!(json!(host.snapshots()), case["before"]);
+        let result = update_edge(
+            &mut host,
+            coord(&case["start"]),
+            case["direction"].as_u64().unwrap() as u8,
+        );
+        assert_eq!(
+            u64::from(result),
+            case["result"].as_u64().unwrap(),
+            "{} return",
+            case["name"]
+        );
+        assert_eq!(
+            json!(host.snapshots()),
+            case["after"],
+            "{} cells",
+            case["name"]
+        );
+        assert_eq!(
+            host.dummy.snapshot(),
+            case["dummy"],
+            "{} dummy",
+            case["name"]
+        );
+        let calls: Vec<_> = case["calls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|event| event["kind"] != "edge_entry")
+            .cloned()
+            .collect();
+        assert_eq!(
+            json!(host.calls),
+            json!(calls),
+            "{} callbacks",
+            case["name"]
+        );
+    }
+}
+
+impl HighBridgeRimHost for SuppliedHost {
+    type Cell = SuppliedHandle;
+    fn tiles(&self) -> HighBridgeRimTiles {
+        self.tiles
+    }
+    fn map_size(&self) -> (i32, i32) {
+        self.size
+    }
+    fn cell(&mut self, coord: RimCoord) -> SuppliedHandle {
+        if let Some(canonical) = Self::canonical(coord).filter(|c| self.cells.contains_key(c)) {
+            SuppliedHandle::Real(canonical)
+        } else {
+            self.dummy.coord = coord;
+            SuppliedHandle::Dummy
+        }
+    }
+    fn read(&self, handle: SuppliedHandle) -> RimCell {
+        let cell = self.by_handle(handle);
+        RimCell {
+            coord: cell.coord,
+            flags: cell.facts.raw_flags,
+            tile: cell.tile,
+            subtile: cell.subtile,
+            anchor: cell.anchor,
+        }
+    }
+    fn allocated(&self, coord: RimCoord) -> bool {
+        Self::canonical(coord).is_some_and(|coord| self.cells.contains_key(&coord))
+    }
+    fn clear_group(&mut self, handle: SuppliedHandle, direction: u8) {
+        let before = self.by_handle(handle).snapshot();
+        let anchor = self.by_handle(handle).coord;
+        self.calls
+            .push(json!({"kind": "setter", "cell": before, "direction": direction, "set": 0}));
+        let stamp = BridgeFlagStamp {
+            anchor,
+            direction,
+            set: false,
+        };
+        for (slot, coord) in stamp.slots().unwrap() {
+            let Some((x, y)) = coord else { continue };
+            let cell = self.get((x as i16, y as i16));
+            apply_bridge_fact_slot(
+                &mut cell.facts,
+                slot,
+                BridgeAnchorRelation {
+                    anchor: (anchor.0 as u16, anchor.1 as u16),
+                    slot,
+                    family: BridgeStampFamily::Nesw,
+                    direction,
+                },
+                false,
+            );
+            if !matches!(slot, BridgeStampSlot::Anchor | BridgeStampSlot::Forward3) {
+                cell.anchor = None;
+            }
+            if matches!(
+                slot,
+                BridgeStampSlot::Anchor
+                    | BridgeStampSlot::Forward1
+                    | BridgeStampSlot::Forward2
+                    | BridgeStampSlot::Opposite
+            ) {
+                let snapshot = cell.snapshot();
+                let coord = cell.coord;
+                self.calls
+                    .push(json!({"kind": "fallout_sink", "cell": snapshot}));
+                self.calls
+                    .push(json!({"kind": "radar_sink", "coord": coord}));
+            }
+        }
+    }
+    fn clear_overlay_and_mark_radar(&mut self, handle: SuppliedHandle) {
+        let cell = self.by_handle_mut(handle);
+        cell.facts.state_byte = 0;
+        cell.facts.overlay_id = None;
+        let coord = cell.coord;
+        self.calls
+            .push(json!({"kind": "radar_sink", "coord": coord}));
+    }
+    fn notify_span(&mut self, first: RimCoord, end: RimCoord) {
+        self.calls
+            .push(json!({"kind": "notify", "endpoints": [first, end]}));
+        notify_span_cells(self, first, end);
+    }
+    fn notify_cell(&mut self, _cell: SuppliedHandle) {}
+    fn mark_span(&mut self, _start: RimCoord, _end: RimCoord) {}
+    fn reset_span_marks(&mut self) {}
+    fn mark_screen(&mut self) {
+        self.calls.push(json!({"kind": "screen_sink"}));
+    }
+}
+
+#[test]
+fn stock_rim_control_matches_original_calls_and_full_cell_changes() {
+    let original: Value = serde_json::from_str(include_str!(
+        "../../../tools/spatial_oracle/bridge_rim.json"
+    ))
+    .unwrap();
+    for case in original["cases"].as_array().unwrap() {
+        let mut host = SuppliedHost::stock();
+        let breaks = case["breaks"].as_array().unwrap();
+        for (index, refresh) in case["refreshes"].as_array().unwrap().iter().enumerate() {
+            if let Some(break_coord) = breaks.get(index) {
+                host.collapse_input(coord(break_coord));
+            }
+            let before = host.snapshots();
+            host.calls.clear();
+            update_adjacent(&mut host, coord(&refresh["coord"]));
+            let changes: Vec<_> = before
+                .into_iter()
+                .zip(host.snapshots())
+                .filter(|(before, after)| before != after)
+                .map(|(before, after)| json!({"before": before, "after": after}))
+                .collect();
+            assert_eq!(
+                json!(changes),
+                refresh["changes"],
+                "{} refresh{index}: fields",
+                case["name"]
+            );
+            // The Rust loop replaces native tail recursion. Compare observable
+            // callback order/receiver snapshots, excluding internal edge entries.
+            let calls: Vec<_> = refresh["calls"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|event| event["kind"] != "edge_entry")
+                .cloned()
+                .collect();
+            assert_eq!(
+                json!(host.calls),
+                json!(calls),
+                "{} refresh{index}: calls",
+                case["name"]
+            );
+        }
+    }
+}

--- a/src/sim/world/bridge_publication.rs
+++ b/src/sim/world/bridge_publication.rs
@@ -1,15 +1,19 @@
 //! Live high-body publication (576BA0/47E040). Authorities stay in Simulation
 //! through synchronous fallout, including recursive DeathWeapon damage.
 //!
-//! Tile-class/pavement and rim callbacks retain their existing Rust projection.
-//! Literal tile replacement, complete56EB80/47D2B0 and rim parity remain open;
-//! do not select raw tile IDs while those callbacks update effective classes.
+//! Rim576770/576200 runs against live scalar cells and uses this same publisher.
+//! Literal tile replacement and complete56EB80/47D2B0 remain open: stock body
+//! sequences in bridge_rim_body prove the tile-untouched production slice only.
+//! In particular terminal middle-tile collapse must eventually publish M+4.
 
 use super::*;
 use crate::map::cell_index::NativeCellIdentity as Cell;
 use crate::map::resolved_terrain::DynamicTerrainCellState;
 use crate::sim::bridge_state::publication::{self, BridgePublicationHost, CellCoord};
 use crate::sim::bridge_state::{BridgeheadAnchorClass, Phase};
+
+#[path = "bridge_rim_publication.rs"]
+mod rim_publication;
 
 #[cfg(test)]
 #[path = "bridge_publication_tests.rs"]
@@ -342,11 +346,7 @@ impl BridgePublicationHost for LivePublication<'_> {
         }
     }
     fn rim(&mut self, coord: CellCoord) {
-        update_adjacent_bridges(
-            self.sim,
-            &BTreeSet::from([(coord.0 as u16, coord.1 as u16)]),
-        );
-        project_pending_low_bridge_overlay_writes(self.sim, self.registry);
+        rim_publication::update(self, coord);
     }
     fn zones(&mut self, _anchor: Cell) {
         refresh_bridge_zones_if_dirty(self.sim, self.rules, true);

--- a/src/sim/world/bridge_publication_tests.rs
+++ b/src/sim/world/bridge_publication_tests.rs
@@ -3,6 +3,9 @@ use crate::map::bridge_facts::{BridgeFlagStamp, BridgeStampFamily};
 use crate::rules::ini_parser::IniFile;
 use crate::sim::overlay_grid::OverlayGrid;
 
+#[path = "bridge_rim_publication_tests.rs"]
+mod rim;
+
 fn rules() -> RuleSet {
     RuleSet::from_ini(&IniFile::from_str(
         "[VehicleTypes]\n0=MTNK\n[MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\n\

--- a/src/sim/world/bridge_rim_publication.rs
+++ b/src/sim/world/bridge_rim_publication.rs
@@ -1,0 +1,108 @@
+//! Live host for the native high-rim selector and restart loop.
+//!
+//! The original untagged575EE0 traversal remains mandatory even on a no-write
+//! refresh, because its GetCell calls can move the retained shared dummy.
+
+use super::*;
+use crate::map::bridge_rim_tiles::HighBridgeRimTiles;
+use crate::sim::bridge_state::rim::{self, HighBridgeRimHost, RimCell, RimCoord};
+
+pub(super) fn update(publication: &mut LivePublication<'_>, input: RimCoord) {
+    let Some(tiles) = publication.terrain().high_bridge_rim_tiles() else {
+        // Synthetic grids without an active theater have no native tile keys.
+        return;
+    };
+    let size = publication
+        .sim
+        .playfield_bounds
+        .zip(publication.sim.playfield_size_height)
+        .map(|(bounds, height)| (bounds.base, height))
+        .or_else(|| {
+            publication
+                .sim
+                .bridge_state
+                .as_ref()?
+                .native_zone_source_size()
+        });
+    let Some(size) = size else { return };
+    rim::update_adjacent(
+        &mut LiveRim {
+            publication,
+            tiles,
+            size,
+        },
+        input,
+    );
+}
+
+struct LiveRim<'a, 'world> {
+    publication: &'a mut LivePublication<'world>,
+    tiles: HighBridgeRimTiles,
+    size: (i32, i32),
+}
+
+impl HighBridgeRimHost for LiveRim<'_, '_> {
+    type Cell = Cell;
+
+    fn tiles(&self) -> HighBridgeRimTiles {
+        self.tiles
+    }
+    fn map_size(&self) -> (i32, i32) {
+        self.size
+    }
+    fn cell(&mut self, coord: RimCoord) -> Cell {
+        self.publication.lookup(coord)
+    }
+    fn read(&self, cell: Cell) -> RimCell {
+        let terrain = self.publication.terrain();
+        let (tile, subtile) = match cell {
+            Cell::Real(index) => {
+                let resolved = &terrain.cells()[index];
+                (resolved.final_tile_index, resolved.final_sub_tile)
+            }
+            // Constructor47BBF0 supplies +38=FFFF/+11A=0. Live dummy tile
+            // replacement is not modeled; no general malformed-map parity is
+            // claimed by the stock corpus. Do not substitute a real cell.
+            Cell::Dummy => (0xffff, 0),
+        };
+        RimCell {
+            coord: self.publication.coord(cell),
+            flags: self.publication.flags(cell),
+            tile,
+            subtile,
+            anchor: terrain
+                .native_cell_anchor(cell)
+                .map(|anchor| terrain.native_cell_coord(anchor)),
+        }
+    }
+    fn allocated(&self, coord: RimCoord) -> bool {
+        self.publication
+            .terrain()
+            .native_fixed_cell_index(coord.0, coord.1)
+            .is_some()
+    }
+    fn clear_group(&mut self, cell: Cell, direction: u8) {
+        publication::set_bridge_direction(self.publication, cell, direction, false);
+    }
+    fn clear_overlay_and_mark_radar(&mut self, cell: Cell) {
+        self.publication.write_state(cell, 0);
+        self.publication.clear_overlay(cell);
+        self.publication.radar(cell);
+    }
+    fn notify_span(&mut self, first: RimCoord, end: RimCoord) {
+        rim::notify_span_cells(self, first, end);
+    }
+    fn notify_cell(&mut self, _cell: Cell) {
+        // TagClass event31 dispatch requires the live trigger authority
+        // (Phase10 rows209/222-224). Keep that behavior explicitly open.
+    }
+    // Native rectangles schedule partial tactical redraws. VERA clears color
+    // and depth and rebuilds/uploads all three bridge batches every frame
+    // (render/build_instances.rs, render/bridges.rs); each reads deck_present.
+    // This no-tile-write mechanism needs no extra retained redraw authority.
+    // Literal56EB80 delivery must also migrate the immutable terrain-template
+    // and presentation-grid consumers; that separate gap remains open.
+    fn mark_span(&mut self, _start: RimCoord, _end: RimCoord) {}
+    fn reset_span_marks(&mut self) {}
+    fn mark_screen(&mut self) {}
+}

--- a/src/sim/world/bridge_rim_publication_tests.rs
+++ b/src/sim/world/bridge_rim_publication_tests.rs
@@ -1,0 +1,289 @@
+//! Actual damage-event caller against original body+perpendicular+rim output.
+//! Stock scalar initialization is shared with Unicorn, not a loader comparison.
+
+use super::*;
+use crate::map::bridge_facts::BridgeCellFacts;
+use crate::map::bridge_rim_tiles::HighBridgeRimTiles;
+use serde_json::{Value, json};
+
+fn stock_world(rules: &RuleSet, input: &Value) -> Simulation {
+    let rows = input["cells"].as_array().unwrap();
+    let height = rows
+        .iter()
+        .map(|r| r[1].as_u64().unwrap() as u16)
+        .max()
+        .unwrap()
+        + 1;
+    let cells = (0..height)
+        .flat_map(|y| {
+            (0..512).map(move |x| {
+                crate::sim::world::lifecycle_tests::common_raw_terrain_cell(x, y, 0, false)
+            })
+        })
+        .collect();
+    let mut terrain = ResolvedTerrainGrid::from_cells(512, height, cells);
+    let mut allocated = Vec::new();
+    let mut grid = OverlayGrid::new_with_retained_wall_plane(512, height);
+    for row in rows {
+        let (x, y, tile, subtile, flags, overlay, state, anchor, level, land): (
+            u16,
+            u16,
+            i32,
+            u8,
+            u32,
+            Option<u8>,
+            u8,
+            Option<(u16, u16)>,
+            u8,
+            u8,
+        ) = serde_json::from_value(row.clone()).unwrap();
+        let index = usize::from(y) * 512 + usize::from(x);
+        allocated.push((x, y));
+        let cell = &mut terrain.cells[index];
+        cell.final_tile_index = tile;
+        cell.final_sub_tile = subtile;
+        cell.level = level;
+        cell.yr_cell_land_type = land;
+        cell.bridge_facts = BridgeCellFacts {
+            state_byte: state,
+            overlay_id: overlay,
+            family: if flags & 0x1f80 != 0 {
+                BridgeStampFamily::Nesw
+            } else {
+                BridgeStampFamily::None
+            },
+            direction: (flags & 0x1f80 != 0).then_some(6),
+            native_anchor: anchor
+                .filter(|_| flags & 0x80 == 0)
+                .map(|(x, y)| Cell::Real(usize::from(y) * 512 + usize::from(x))),
+            ..Default::default()
+        };
+        terrain.write_native_cell_flags(Cell::Real(index), flags);
+        if let Some(overlay) = overlay {
+            grid.place_overlay(x, y, overlay, state);
+        }
+        grid.write_literal_bridge_state(&mut terrain, x, y, state);
+    }
+    terrain.test_set_native_allocated_cells(&allocated);
+    let mut ini = String::from("[General]\n");
+    for (key, value) in input["rim_keys"].as_object().unwrap() {
+        ini.push_str(&format!("{key}={value}\n"));
+    }
+    terrain.test_set_high_bridge_rim_tiles(HighBridgeRimTiles::from_ini(
+        input["bridge_base"].as_i64().unwrap() as i32,
+        ini.as_bytes(),
+    ));
+    let size = serde_json::from_value(input["size"].clone()).unwrap();
+    let state = BridgeRuntimeState::from_resolved_terrain_with_map_size(&terrain, true, 1, size);
+    let mut sim = Simulation::with_seed(31);
+    sim.intern_rule_type_ids(rules);
+    sim.resolve_type_handles(rules);
+    sim.install_resolved_terrain_for_new_map(terrain);
+    sim.bridge_state = Some(state);
+    sim.overlay_grid = Some(grid);
+    sim
+}
+
+fn snapshot(sim: &Simulation, coord: (u16, u16)) -> Value {
+    let terrain = sim.resolved_terrain.as_ref().unwrap();
+    let cell = terrain.cell(coord.0, coord.1).unwrap();
+    json!({"coord": coord, "flags": cell.bridge_facts.raw_flags,
+        "state": cell.bridge_facts.state_byte,
+        "overlay": cell.bridge_facts.overlay_id.map_or(-1, i32::from),
+        "anchor": cell.bridge_facts.native_anchor.map(|a| terrain.native_cell_coord(a))})
+}
+
+#[test]
+fn bridge_rim_stock_damage_events_match_original_body_perpendicular_and_cleanup() {
+    let input: Value = serde_json::from_str(include_str!(
+        "../../../tools/spatial_oracle/bridge_rim_stock_inputs.json"
+    ))
+    .unwrap();
+    let original: Value = serde_json::from_str(include_str!(
+        "../../../tools/spatial_oracle/bridge_rim_body.json"
+    ))
+    .unwrap();
+    let coords: Vec<(u16, u16)> = input["cells"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| (r[0].as_u64().unwrap() as u16, r[1].as_u64().unwrap() as u16))
+        .collect();
+    let rules = rules();
+    for case in original["cases"].as_array().unwrap() {
+        let mut sim = stock_world(&rules, &input);
+        let mut expected: std::collections::BTreeMap<_, _> =
+            coords.iter().map(|&c| (c, snapshot(&sim, c))).collect();
+        for hit in case["hits"].as_array().unwrap() {
+            let coord = serde_json::from_value(hit["input"].clone()).unwrap();
+            let mut damage = event(&mut sim, coord);
+            damage.impact_z = i32::from(
+                sim.resolved_terrain
+                    .as_ref()
+                    .unwrap()
+                    .cell(coord.0, coord.1)
+                    .unwrap()
+                    .level,
+            );
+            sim.radar_terrain_dirty_cells.clear();
+            let collapsed =
+                apply_bridge_damage_events_with_overlay_registry(&mut sim, &rules, &[damage], None);
+            let calls = hit["calls"].as_array().unwrap();
+            assert_eq!(
+                collapsed,
+                calls.iter().any(|c| c["kind"] == "fallout_sink"),
+                "{} at{coord:?}",
+                case["name"]
+            );
+            for change in hit["changes"].as_array().unwrap() {
+                let coord = serde_json::from_value(change["before"]["coord"].clone()).unwrap();
+                assert_eq!(expected[&coord], change["before"]);
+                expected.insert(coord, change["after"].clone());
+            }
+            for (&coord, wanted) in &expected {
+                assert_eq!(
+                    &snapshot(&sim, coord),
+                    wanted,
+                    "{} hit{} at{coord:?}",
+                    case["name"],
+                    hit["input"]
+                );
+            }
+            let mut radar: Vec<(u16, u16)> = Vec::new();
+            for call in calls.iter().filter(|c| c["kind"] == "radar_sink") {
+                let coord = serde_json::from_value(call["coord"].clone()).unwrap();
+                if !radar.contains(&coord) {
+                    radar.push(coord);
+                }
+            }
+            assert_eq!(
+                sim.radar_terrain_dirty_cells, radar,
+                "{} hit{} radar",
+                case["name"], hit["input"]
+            );
+            for change in hit["changes"].as_array().unwrap() {
+                let coord: (u16, u16) =
+                    serde_json::from_value(change["after"]["coord"].clone()).unwrap();
+                let terrain = sim
+                    .resolved_terrain
+                    .as_ref()
+                    .unwrap()
+                    .cell(coord.0, coord.1)
+                    .unwrap();
+                assert_eq!(
+                    sim.dynamic_terrain_cells[&coord],
+                    DynamicTerrainCellState::capture(terrain)
+                );
+                if change["before"]["flags"].as_u64().unwrap() & 0x100 != 0
+                    && change["after"]["flags"].as_u64().unwrap() & 0x100 == 0
+                {
+                    assert!(!terrain.has_bridge_deck && !terrain.bridge_walkable);
+                    assert!(
+                        !sim.path_grid()
+                            .unwrap()
+                            .cell(coord.0, coord.1)
+                            .unwrap()
+                            .bridge_walkable
+                    );
+                    assert!(
+                        !sim.bridge_state
+                            .as_ref()
+                            .unwrap()
+                            .cell(coord.0, coord.1)
+                            .unwrap()
+                            .deck_present
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn bridge_rim_middle_section_fallout_and_restored_navigation() {
+    let input: Value = serde_json::from_str(include_str!(
+        "../../../tools/spatial_oracle/bridge_rim_stock_inputs.json"
+    ))
+    .unwrap();
+    let rules = rules();
+    let mut sim = stock_world(&rules, &input);
+    let pristine = sim.resolved_terrain.as_ref().unwrap().clone();
+    let victim = sim
+        .construct_object_limbo_at_height("MTNK", "Americans", 111, 142, 0, 0, &rules)
+        .unwrap();
+    sim.reveal(victim);
+    for (index, coord) in [(112, 140), (112, 140), (112, 144), (112, 144)]
+        .into_iter()
+        .enumerate()
+    {
+        let mut damage = event(&mut sim, coord);
+        damage.impact_z = i32::from(
+            sim.resolved_terrain
+                .as_ref()
+                .unwrap()
+                .cell(coord.0, coord.1)
+                .unwrap()
+                .level,
+        );
+        apply_bridge_damage_events_with_overlay_registry(&mut sim, &rules, &[damage], None);
+        let alive = sim
+            .substrate
+            .entities
+            .get(victim)
+            .is_some_and(|unit| unit.health.current > 0);
+        assert_eq!(
+            alive,
+            index < 3,
+            "only the final rim group clear reaches this ground occupant"
+        );
+    }
+    let bytes = crate::sim::snapshot::GameSnapshot::save(&sim, 0, 0, "stock-rim", 0);
+    let mut restored = crate::sim::snapshot::GameSnapshot::load(&bytes)
+        .unwrap()
+        .sim;
+    restored.restore_after_snapshot_load().unwrap();
+    restored.rebuild_caches_after_load(
+        pristine,
+        Default::default(),
+        Vec::new(),
+        Vec::new(),
+        BTreeMap::new(),
+    );
+    restored
+        .restore_map_authority_after_snapshot_load(
+            &rules,
+            &crate::map::overlay_types::OverlayTypeRegistry::empty(),
+        )
+        .unwrap();
+    for y in 140..=144 {
+        for x in 110..=113 {
+            assert_eq!(snapshot(&sim, (x, y)), snapshot(&restored, (x, y)));
+            assert!(
+                !restored
+                    .path_grid()
+                    .unwrap()
+                    .cell(x, y)
+                    .unwrap()
+                    .bridge_walkable
+            );
+            assert!(
+                !restored
+                    .bridge_state
+                    .as_ref()
+                    .unwrap()
+                    .cell(x, y)
+                    .unwrap()
+                    .deck_present
+            );
+        }
+    }
+    assert_eq!(sim.dynamic_terrain_cells, restored.dynamic_terrain_cells);
+    assert!(
+        restored
+            .resolved_terrain
+            .as_ref()
+            .unwrap()
+            .high_bridge_rim_tiles()
+            .is_some()
+    );
+}

--- a/tools/spatial_oracle/bridge_rim_body.json
+++ b/tools/spatial_oracle/bridge_rim_body.json
@@ -1,0 +1,5465 @@
+{
+  "cases": [
+    {
+      "hits": [
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 4,
+              "function": "ew_damage_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 0,
+              "function": "ew_damage_b",
+              "kind": "perpendicular"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            }
+          ],
+          "input": [
+            112,
+            140
+          ],
+          "returned": 0
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 4,
+              "function": "ew_collapse_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 0,
+              "function": "ew_collapse_b",
+              "kind": "perpendicular"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "rim"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "zone_sink"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  140
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  140
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  140
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  114,
+                  140
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              }
+            }
+          ],
+          "input": [
+            112,
+            140
+          ],
+          "returned": 1
+        }
+      ],
+      "name": "single_section"
+    },
+    {
+      "hits": [
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 4,
+              "function": "ew_damage_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 0,
+              "function": "ew_damage_b",
+              "kind": "perpendicular"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            }
+          ],
+          "input": [
+            112,
+            140
+          ],
+          "returned": 0
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 4,
+              "function": "ew_collapse_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 0,
+              "function": "ew_collapse_b",
+              "kind": "perpendicular"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "rim"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "zone_sink"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  140
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  140
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  140
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  114,
+                  140
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              }
+            }
+          ],
+          "input": [
+            112,
+            140
+          ],
+          "returned": 1
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 4,
+              "function": "ew_damage_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 0,
+              "function": "ew_damage_b",
+              "kind": "perpendicular"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            }
+          ],
+          "input": [
+            112,
+            144
+          ],
+          "returned": 0
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 4,
+              "function": "ew_collapse_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 0,
+              "function": "ew_collapse_b",
+              "kind": "perpendicular"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "kind": "rim"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "kind": "screen_sink"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "kind": "zone_sink"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  141
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  141
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  141
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  114,
+                  141
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  142
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  142
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  142
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  114,
+                  142
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  143
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  143
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  143
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  114,
+                  143
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  144
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  144
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  144
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  114,
+                  144
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              }
+            }
+          ],
+          "input": [
+            112,
+            144
+          ],
+          "returned": 1
+        }
+      ],
+      "name": "two_breaks_remove_middle"
+    },
+    {
+      "hits": [
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 4,
+              "function": "ew_damage_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 0,
+              "function": "ew_damage_b",
+              "kind": "perpendicular"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            }
+          ],
+          "input": [
+            112,
+            144
+          ],
+          "returned": 0
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 4,
+              "function": "ew_collapse_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 0,
+              "function": "ew_collapse_b",
+              "kind": "perpendicular"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "kind": "rim"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "kind": "zone_sink"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  144
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  144
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  144
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  114,
+                  144
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              }
+            }
+          ],
+          "input": [
+            112,
+            144
+          ],
+          "returned": 1
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 4,
+              "function": "ew_damage_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 0,
+              "function": "ew_damage_b",
+              "kind": "perpendicular"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            }
+          ],
+          "input": [
+            112,
+            140
+          ],
+          "returned": 0
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 4,
+              "function": "ew_collapse_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 0,
+              "function": "ew_collapse_b",
+              "kind": "perpendicular"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "rim"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "kind": "screen_sink"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "zone_sink"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  140
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  140
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  140
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  114,
+                  140
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  141
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  141
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  141
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  114,
+                  141
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  142
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  142
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  142
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  114,
+                  142
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  143
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  143
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  143
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  114,
+                  143
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            }
+          ],
+          "input": [
+            112,
+            140
+          ],
+          "returned": 1
+        }
+      ],
+      "name": "reverse_breaks_remove_middle"
+    },
+    {
+      "hits": [
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 4,
+              "function": "ew_damage_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 0,
+              "function": "ew_damage_b",
+              "kind": "perpendicular"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            }
+          ],
+          "input": [
+            111,
+            140
+          ],
+          "returned": 0
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 4,
+              "function": "ew_collapse_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "direction": 0,
+              "function": "ew_collapse_b",
+              "kind": "perpendicular"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                140
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                111,
+                140
+              ],
+              "kind": "rim"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "coord": [
+                112,
+                140
+              ],
+              "kind": "zone_sink"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  139
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  140
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  140
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  110,
+                  140
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  111,
+                  140
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  140
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  113,
+                  140
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  140
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  140
+                ],
+                "coord": [
+                  114,
+                  140
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              }
+            }
+          ],
+          "input": [
+            111,
+            140
+          ],
+          "returned": 1
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 4,
+              "function": "ew_damage_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 0,
+              "function": "ew_damage_b",
+              "kind": "perpendicular"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            }
+          ],
+          "input": [
+            111,
+            144
+          ],
+          "returned": 0
+        },
+        {
+          "calls": [
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 4,
+              "function": "ew_collapse_a",
+              "kind": "perpendicular"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "direction": 0,
+              "function": "ew_collapse_b",
+              "kind": "perpendicular"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                144
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                111,
+                144
+              ],
+              "kind": "rim"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 16
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                143
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                142
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "direction": 6,
+              "kind": "setter",
+              "set": 0
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": 25,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                112,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                111,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                110,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "cell": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "kind": "fallout_sink"
+            },
+            {
+              "coord": [
+                113,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                141
+              ],
+              "kind": "radar_sink"
+            },
+            {
+              "coord": [
+                112,
+                135
+              ],
+              "direction": 4,
+              "kind": "edge_entry"
+            },
+            {
+              "endpoints": [
+                [
+                  112,
+                  136
+                ],
+                [
+                  112,
+                  152
+                ]
+              ],
+              "kind": "notify"
+            },
+            {
+              "kind": "screen_sink"
+            },
+            {
+              "coord": [
+                112,
+                144
+              ],
+              "kind": "zone_sink"
+            }
+          ],
+          "changes": [
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  141
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  141
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  110,
+                  141
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  111,
+                  141
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  141
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  113,
+                  141
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  141
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  141
+                ],
+                "coord": [
+                  114,
+                  141
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  142
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  142
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  110,
+                  142
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  111,
+                  142
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  142
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  113,
+                  142
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  142
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  142
+                ],
+                "coord": [
+                  114,
+                  142
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  143
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  143
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  110,
+                  143
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  111,
+                  143
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  143
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 13
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  113,
+                  143
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  143
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  143
+                ],
+                "coord": [
+                  114,
+                  143
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  144
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  109,
+                  144
+                ],
+                "flags": 4096,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  110,
+                  144
+                ],
+                "flags": 69888,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  111,
+                  144
+                ],
+                "flags": 70400,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  144
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 15
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 1024,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  113,
+                  144
+                ],
+                "flags": 66304,
+                "overlay": -1,
+                "state": 9
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  114,
+                  144
+                ],
+                "flags": 0,
+                "overlay": -1,
+                "state": 0
+              },
+              "before": {
+                "anchor": [
+                  112,
+                  144
+                ],
+                "coord": [
+                  114,
+                  144
+                ],
+                "flags": 65536,
+                "overlay": -1,
+                "state": 0
+              }
+            },
+            {
+              "after": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 17
+              },
+              "before": {
+                "anchor": null,
+                "coord": [
+                  112,
+                  145
+                ],
+                "flags": 70528,
+                "overlay": 25,
+                "state": 14
+              }
+            }
+          ],
+          "input": [
+            111,
+            144
+          ],
+          "returned": 1
+        }
+      ],
+      "name": "nonanchor_two_breaks"
+    }
+  ],
+  "stock_input_sha256": "68e8ecbe0e66b622a78709d02a50041f1bfad8c9f1141102ba987cc4b910fd91"
+}

--- a/tools/spatial_oracle/bridge_rim_body.meta.json
+++ b/tools/spatial_oracle/bridge_rim_body.meta.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "Original576BA0 body, actual EW perpendicular helpers,576770/576200 rim and47E040 across stock consecutive hits",
+  "assumptions": [
+    "225 stock xbayopigs scalar cells supplied by the current Rust loader; native loader and outer damage/RNG admission excluded",
+    "All hits begin from the real stock state9; no intermediate state bytes are supplied",
+    "Both input orders and nonanchor inputs covered; only the named vertical stock span is certified",
+    "Every actual perpendicular instruction executes; reaching56EB80 or56E990 fails the corpus instead of substituting tile writes",
+    "All225 tile/subtile identities are asserted unchanged after every hit; terminal middle-ramp tile collapse remains outside this witness",
+    "No objects or CellTags supplied; untagged575EE0 executes; live tag dispatch is excluded"
+  ],
+  "substitutions": [
+    "47DD70 fallout receiver,6551C0 radar,6D2140 screen projection and6D2790 screen sinks inherited from bridge_rim",
+    "56DAE0 connectivity rebuild records coordinate and returns0; connectivity internals excluded",
+    "No body, perpendicular, rim, setter, or notification instructions replaced"
+  ],
+  "entry_points": {
+    "body": "0x00576BA0",
+    "selector": "0x00576770",
+    "edge": "0x00576200",
+    "setter": "0x0047E040",
+    "notification": "0x00575EE0",
+    "ew_damage_a": "0x00572B80",
+    "ew_damage_b": "0x00572C90",
+    "ew_collapse_a": "0x00572DA0",
+    "ew_collapse_b": "0x00573170"
+  },
+  "payload_sha256": "3fdb96c3c67137401ef8af5896b154c7284b543602935c8883b8fcbb0c67633a"
+}

--- a/tools/spatial_oracle/bridge_rim_body.py
+++ b/tools/spatial_oracle/bridge_rim_body.py
@@ -1,0 +1,91 @@
+"""Original high-body hits, real perpendicular helpers, and live rim cleanup.
+
+The stock witness deliberately covers cells whose perpendicular calls never
+write tiles. Fail if a sequence reaches a tile writer; do not substitute one.
+Object fallout, radar, screen and connectivity outputs remain declared sinks.
+"""
+import hashlib
+import json
+from pathlib import Path
+import struct
+
+from unicorn.x86_const import UC_X86_REG_EAX, UC_X86_REG_EIP, UC_X86_REG_ESP
+from tools.native_oracle import finish_vectors, provenance
+from tools.spatial_oracle.bridge_rim import OriginalRim, COORD
+from tools.spatial_oracle.bridge_body_publication import PERPENDICULAR
+from tools.spatial_oracle.map_queries import packed
+
+
+class OriginalRimBody(OriginalRim):
+    def observe(self, u, address, size, data):
+        if address in (0x56EB80, 0x56E990):
+            raise AssertionError(f'Unexpected tile/pavement writer {address:08X}')
+        if address in PERPENDICULAR or address in (0x576770, 0x56DAE0):
+            sp = u.reg_read(UC_X86_REG_ESP)
+            args = struct.unpack('<2I', u.mem_read(sp + 4, 8))
+            coord = list(struct.unpack('<hh', u.mem_read(args[0], 4)))
+            if address in PERPENDICULAR:
+                self.events.append(dict(kind='perpendicular', function=PERPENDICULAR[address],
+                                        coord=coord, direction=args[1]))
+                return  # Execute every original helper instruction.
+            if address == 0x576770:
+                self.events.append(dict(kind='rim', coord=coord))
+                return  # Execute the selector, edge loop and notifications.
+            self.events.append(dict(kind='zone_sink', coord=coord))
+            destination = struct.unpack('<I', u.mem_read(sp, 4))[0]
+            u.reg_write(UC_X86_REG_EAX, 0)
+            u.reg_write(UC_X86_REG_ESP, sp + 8)
+            u.reg_write(UC_X86_REG_EIP, destination)
+            return
+        super().observe(u, address, size, data)
+
+
+def cases():
+    source = Path(__file__).with_name('bridge_rim_stock_inputs.json')
+    case = json.loads(source.read_text(encoding='utf-8'))
+    results = []
+    for name, hits in (
+        ('single_section', [(112, 140)] * 2),
+        ('two_breaks_remove_middle', [(112, 140)] * 2 + [(112, 144)] * 2),
+        ('reverse_breaks_remove_middle', [(112, 144)] * 2 + [(112, 140)] * 2),
+        ('nonanchor_two_breaks', [(111, 140)] * 2 + [(111, 144)] * 2),
+    ):
+        native = OriginalRimBody(case)
+        steps = []
+        for coord in hits:
+            before = {c: native.snapshot(p) for c, p in native.ptrs.items()}
+            native.events.clear()
+            native.writes.clear()
+            native.uc.mem_write(COORD, packed(*coord))
+            returned = native.call(0x576BA0, args=(COORD,))
+            # These fields stay live and readable for the actual rim selector.
+            for x, y, tile, sub, *_ in case['cells']:
+                p = native.ptrs[x, y]
+                assert struct.unpack('<i', native.uc.mem_read(p + 0x38, 4))[0] == tile
+                assert bytes(native.uc.mem_read(p + 0x11A, 1))[0] == sub
+            steps.append(dict(input=coord, returned=returned, calls=list(native.events),
+                              changes=[dict(before=before[c], after=native.snapshot(p))
+                                       for c, p in native.ptrs.items()
+                                       if before[c] != native.snapshot(p)]))
+        results.append(dict(name=name, hits=steps))
+    return dict(stock_input_sha256=hashlib.sha256(source.read_bytes()).hexdigest(), cases=results)
+
+
+if __name__ == '__main__':
+    finish_vectors(cases, Path(__file__).with_suffix('.json'), provenance=lambda: provenance(
+        scope='Original576BA0 body, actual EW perpendicular helpers,576770/576200 rim and47E040 across stock consecutive hits',
+        assumptions=[
+            '225 stock xbayopigs scalar cells supplied by the current Rust loader; native loader and outer damage/RNG admission excluded',
+            'All hits begin from the real stock state9; no intermediate state bytes are supplied',
+            'Both input orders and nonanchor inputs covered; only the named vertical stock span is certified',
+            'Every actual perpendicular instruction executes; reaching56EB80 or56E990 fails the corpus instead of substituting tile writes',
+            'All225 tile/subtile identities are asserted unchanged after every hit; terminal middle-ramp tile collapse remains outside this witness',
+            'No objects or CellTags supplied; untagged575EE0 executes; live tag dispatch is excluded',
+        ], substitutions=[
+            '47DD70 fallout receiver,6551C0 radar,6D2140 screen projection and6D2790 screen sinks inherited from bridge_rim',
+            '56DAE0 connectivity rebuild records coordinate and returns0; connectivity internals excluded',
+            'No body, perpendicular, rim, setter, or notification instructions replaced',
+        ], entry_points={'body': 0x576BA0, 'selector': 0x576770, 'edge': 0x576200,
+                         'setter': 0x47E040, 'notification': 0x575EE0,
+                         'ew_damage_a': 0x572B80, 'ew_damage_b': 0x572C90,
+                         'ew_collapse_a': 0x572DA0, 'ew_collapse_b': 0x573170}))

--- a/tools/spatial_oracle/bridge_rim_control.json
+++ b/tools/spatial_oracle/bridge_rim_control.json
@@ -1,0 +1,300 @@
+{
+  "cases": [
+    {
+      "after": [
+        {
+          "anchor": null,
+          "coord": [
+            100,
+            100
+          ],
+          "flags": 128,
+          "overlay": -1,
+          "state": 0
+        },
+        {
+          "anchor": null,
+          "coord": [
+            102,
+            100
+          ],
+          "flags": 128,
+          "overlay": -1,
+          "state": 0
+        },
+        {
+          "anchor": null,
+          "coord": [
+            104,
+            100
+          ],
+          "flags": 0,
+          "overlay": -1,
+          "state": 0
+        }
+      ],
+      "before": [
+        {
+          "anchor": null,
+          "coord": [
+            100,
+            100
+          ],
+          "flags": 128,
+          "overlay": -1,
+          "state": 0
+        },
+        {
+          "anchor": null,
+          "coord": [
+            102,
+            100
+          ],
+          "flags": 128,
+          "overlay": -1,
+          "state": 0
+        },
+        {
+          "anchor": null,
+          "coord": [
+            104,
+            100
+          ],
+          "flags": 0,
+          "overlay": -1,
+          "state": 0
+        }
+      ],
+      "calls": [
+        {
+          "coord": [
+            100,
+            100
+          ],
+          "direction": 2,
+          "kind": "edge_entry"
+        },
+        {
+          "endpoints": [
+            [
+              101,
+              100
+            ],
+            [
+              104,
+              100
+            ]
+          ],
+          "kind": "notify"
+        }
+      ],
+      "direction": 2,
+      "dummy": {
+        "anchor": null,
+        "coord": [
+          106,
+          98
+        ],
+        "flags": 0,
+        "overlay": -1,
+        "state": 0
+      },
+      "input": {
+        "bridge_base": 0,
+        "cells": [
+          [
+            100,
+            100,
+            0,
+            0,
+            128,
+            null,
+            0,
+            null,
+            0,
+            0
+          ],
+          [
+            102,
+            100,
+            0,
+            0,
+            128,
+            null,
+            0,
+            null,
+            0,
+            0
+          ],
+          [
+            104,
+            100,
+            200,
+            4,
+            0,
+            null,
+            0,
+            null,
+            0,
+            0
+          ]
+        ],
+        "rim_keys": {
+          "BridgeBottomLeft1": 9060,
+          "BridgeBottomLeft2": 9070,
+          "BridgeBottomRight1": 201,
+          "BridgeBottomRight2": 9030,
+          "BridgeMiddle1": 9080,
+          "BridgeMiddle2": 9090,
+          "BridgeTopLeft1": 9000,
+          "BridgeTopLeft2": 9010,
+          "BridgeTopRight1": 9040,
+          "BridgeTopRight2": 9050
+        },
+        "size": [
+          136,
+          140
+        ]
+      },
+      "name": "notification_moves_retained_dummy",
+      "result": 0,
+      "start": [
+        100,
+        100
+      ],
+      "writes": []
+    },
+    {
+      "after": [
+        {
+          "anchor": null,
+          "coord": [
+            511,
+            100
+          ],
+          "flags": 0,
+          "overlay": -1,
+          "state": 0
+        },
+        {
+          "anchor": null,
+          "coord": [
+            0,
+            101
+          ],
+          "flags": 0,
+          "overlay": -1,
+          "state": 0
+        }
+      ],
+      "before": [
+        {
+          "anchor": null,
+          "coord": [
+            511,
+            100
+          ],
+          "flags": 0,
+          "overlay": -1,
+          "state": 0
+        },
+        {
+          "anchor": null,
+          "coord": [
+            0,
+            101
+          ],
+          "flags": 0,
+          "overlay": -1,
+          "state": 0
+        }
+      ],
+      "calls": [
+        {
+          "coord": [
+            511,
+            100
+          ],
+          "direction": 2,
+          "kind": "edge_entry"
+        },
+        {
+          "endpoints": [
+            [
+              512,
+              100
+            ],
+            [
+              512,
+              100
+            ]
+          ],
+          "kind": "notify"
+        }
+      ],
+      "direction": 2,
+      "dummy": {
+        "anchor": null,
+        "coord": [
+          0,
+          0
+        ],
+        "flags": 0,
+        "overlay": -1,
+        "state": 0
+      },
+      "input": {
+        "bridge_base": 0,
+        "cells": [
+          [
+            511,
+            100,
+            0,
+            0,
+            0,
+            null,
+            0,
+            null,
+            0,
+            0
+          ],
+          [
+            0,
+            101,
+            200,
+            4,
+            0,
+            null,
+            0,
+            null,
+            0,
+            0
+          ]
+        ],
+        "rim_keys": {
+          "BridgeBottomLeft1": 9060,
+          "BridgeBottomLeft2": 9070,
+          "BridgeBottomRight1": 201,
+          "BridgeBottomRight2": 9030,
+          "BridgeMiddle1": 9080,
+          "BridgeMiddle2": 9090,
+          "BridgeTopLeft1": 9000,
+          "BridgeTopLeft2": 9010,
+          "BridgeTopRight1": 9040,
+          "BridgeTopRight2": 9050
+        },
+        "size": [
+          136,
+          140
+        ]
+      },
+      "name": "requested_endpoint_before_fixed_stride_alias",
+      "result": 0,
+      "start": [
+        511,
+        100
+      ],
+      "writes": []
+    }
+  ]
+}

--- a/tools/spatial_oracle/bridge_rim_control.meta.json
+++ b/tools/spatial_oracle/bridge_rim_control.meta.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "Original576200, actual untagged575EE0, retained dummy and requested endpoint control cases",
+  "assumptions": [
+    "Synthetic sparse supplied cells; not a stock-map reachability claim",
+    "Direct edge entry direction2 with null rectangle; selector and display work excluded",
+    "Missing slots share the original dummy initialized with tile=-1, no tags/objects"
+  ],
+  "substitutions": [
+    "Inherited OriginalRim output sinks; neither case enters a setter or object fallout"
+  ],
+  "entry_points": {
+    "edge": "0x00576200",
+    "notification": "0x00575EE0",
+    "lookup": "0x005657A0"
+  },
+  "payload_sha256": "fb53dc91ef050de8b169df7dbfdd282ddabd49a0b3b202c04d4a1abfbc211e9c"
+}

--- a/tools/spatial_oracle/bridge_rim_control.py
+++ b/tools/spatial_oracle/bridge_rim_control.py
@@ -1,0 +1,47 @@
+"""Original edge-loop pointer retention across untagged notifications.
+
+Synthetic control cases complement, but do not broaden, the retail stock
+witness. No original object damage or whole-world loader is claimed.
+"""
+from pathlib import Path
+from tools.native_oracle import finish_vectors, provenance
+from tools.spatial_oracle.bridge_rim import OriginalRim, GLOBALS, COORD, DUMMY
+from tools.spatial_oracle.map_queries import packed
+
+
+def cases():
+    results = []
+    for name, rows, start in [
+        ('notification_moves_retained_dummy', [
+            [100, 100, 0, 0, 0x80, None, 0, None, 0, 0],
+            [102, 100, 0, 0, 0x80, None, 0, None, 0, 0],
+            [104, 100, 200, 4, 0, None, 0, None, 0, 0],
+        ], [100, 100]),
+        ('requested_endpoint_before_fixed_stride_alias', [
+            [511, 100, 0, 0, 0, None, 0, None, 0, 0],
+            [0, 101, 200, 4, 0, None, 0, None, 0, 0],
+        ], [511, 100]),
+    ]:
+        keys = {key: 9000+i*10 for i, key in enumerate(GLOBALS)}
+        keys['BridgeBottomRight1'] = 201
+        supplied = dict(bridge_base=0, rim_keys=keys, size=[136, 140], cells=rows)
+        native = OriginalRim(supplied)
+        before = [native.snapshot(p) for p in native.ptrs.values()]
+        native.uc.mem_write(COORD, packed(*start))
+        result = native.call(0x576200, args=(COORD, 2, 0))
+        results.append(dict(name=name, input=supplied, start=start, direction=2,
+            result=result, before=before, after=[native.snapshot(p) for p in native.ptrs.values()],
+            calls=native.events, writes=native.writes, dummy=native.snapshot(DUMMY)))
+    return dict(cases=results)
+
+
+if __name__ == '__main__':
+    finish_vectors(cases, Path(__file__).with_suffix('.json'), provenance=lambda: provenance(
+        scope='Original576200, actual untagged575EE0, retained dummy and requested endpoint control cases',
+        assumptions=[
+            'Synthetic sparse supplied cells; not a stock-map reachability claim',
+            'Direct edge entry direction2 with null rectangle; selector and display work excluded',
+            'Missing slots share the original dummy initialized with tile=-1, no tags/objects',
+        ], substitutions=[
+            'Inherited OriginalRim output sinks; neither case enters a setter or object fallout',
+        ], entry_points={'edge':0x576200, 'notification':0x575EE0, 'lookup':0x5657A0}))


### PR DESCRIPTION
Breaking two nearby sections of a high bridge could leave the sections between them standing. The ordinary high-body damage path now runs the original flag/tile selector and cleanup restart sequence, removing those stranded sections through the existing live publisher. Each group publishes its fields before unit fallout and radar callbacks; navigation and saved state receive the removed deck.

The active theater supplies all ten signed rim keys. Cleanup preserves the original search limit, retained cell identities, callback order, and untagged notification lookups. Tactical drawing already rebuilds bridge batches from live deck state each frame.

Native evidence comes from `bridge_rim`, `bridge_rim_control`, and the new `bridge_rim_body` corpora. The latter executes the original body, actual perpendicular helpers, rim, setter, and untagged notification loop for four stock hit sequences. It rejects tile-writer entry. Production damage events match all 225 stock scalar cells after every hit and radar order; separate tests cover the middle-section casualty and save/load navigation.

This is a bounded stock slice. Terminal middle-ramp tile replacement (including the confirmed relative M+4 result), mixed tile-changing histories, live event31 dispatch, general dummy behavior, and the legacy head/hut/direct callers remain open. No Phase 3 row is closed.

Validation: full `cargo test -p vera20k --lib` passed with 8,682 passed, 0 failed, 121 ignored. `cargo clippy -p vera20k --lib` exited 0 with the same 1,147 warnings as main. Both core comparisons and both production tests passed. All three native corpora were independently reproduced, and a fresh read-only critic reviewed the final source and consumers.
