### PR TITLE
Preserve native terrain attributes through tile recalculation

### DIFF
--- a/src/map/lat.rs
+++ b/src/map/lat.rs
@@ -341,7 +341,9 @@ pub(crate) fn slope_fixed_tile_live(
         };
         config.ramp_smooth + i32::from(block_offset)
     } else {
-        config.ramp_base + i32::from(slope.wrapping_sub(1))
+        // 47D1C0..47D1C8 zero-extends11C before DWORD LEA arithmetic.
+        // The subtraction does not wrap in a byte: slope0 selects base-1.
+        config.ramp_base.wrapping_add(i32::from(slope)).wrapping_sub(1)
     }
 }
 
@@ -720,7 +722,7 @@ RoughConnectTo=14
     }
 
     #[test]
-    fn gsi_04_03a_zero_and_unsigned_high_slopes_use_wrapping_fallback() {
+    fn gsi_04_03a_zero_and_unsigned_high_slopes_use_dword_fallback() {
         let config = SlopeFixupConfig {
             ramp_base: 100,
             ramp_smooth: 500,
@@ -728,7 +730,7 @@ RoughConnectTo=14
         for slope in [0, 5, 16, 127, 128, 255] {
             assert_eq!(
                 slope_fixed_tile(100, slope, [0; 4], config),
-                100 + i32::from(slope.wrapping_sub(1)),
+                100 + i32::from(slope) - 1,
                 "slope {slope}",
             );
         }
@@ -742,12 +744,12 @@ RoughConnectTo=14
         };
         for (tile, expected) in [
             (99, 99),
-            (100, 355),
-            (119, 355),
+            (100, 99),
+            (119, 99),
             (120, 120),
             (499, 499),
-            (500, 355),
-            (511, 355),
+            (500, 99),
+            (511, 99),
             (512, 512),
         ] {
             assert_eq!(slope_fixed_tile(tile, 0, [9; 4], config), expected);
@@ -766,7 +768,7 @@ RoughConnectTo=14
                     ramp_smooth: 500,
                 },
             ),
-            254,
+            -2,
             "missing RampBase still owns fallback arithmetic",
         );
         assert_eq!(

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -1842,6 +1842,20 @@ impl ResolvedTerrainGrid {
         overlay: FinalizedOverlayCell,
         effects: &mut E,
     ) -> Result<LoadCellRecalcOutcome, LoadCellRecalcError<E::Error>> {
+        self.recalc_cell_attributes(state, index, overlay, -1, effects)
+    }
+
+    /// Shared47D2B0 entry: only the valid normal-TMP branch consumes the
+    /// level override, after Tube construction and before dimensions/Anim.
+    /// Evidence: tools/spatial_oracle/terrain_recalc.
+    pub(crate) fn recalc_cell_attributes<E: LoadCellRecalcEffects>(
+        &mut self,
+        state: &mut LoadCellRecalcState<'_>,
+        index: usize,
+        overlay: FinalizedOverlayCell,
+        level_override: i32,
+        effects: &mut E,
+    ) -> Result<LoadCellRecalcOutcome, LoadCellRecalcError<E::Error>> {
         let Some(snapshot) = self.cells.get(index).cloned() else {
             return Err(LoadCellRecalcError::CellIndexOutOfBounds { index });
         };
@@ -1872,6 +1886,9 @@ impl ResolvedTerrainGrid {
         let mut anim_request = None;
         let mut animation_tile_id = None;
         let mut animation_sub_tile = 0;
+        let mut valid_entry = false;
+        let mut sparse_entry = false;
+        let mut retained_height_in_pixels = snapshot.height_in_pixels;
 
         if early_overlay_branch {
             let flags = source_flags.expect("early branch has OverlayType flags");
@@ -1927,10 +1944,10 @@ impl ResolvedTerrainGrid {
             let current_sub_tile = snapshot.final_sub_tile;
             let registered =
                 state.registered_tile_metadata(current_tile, current_sub_tile, &snapshot);
-            let sparse_entry = registered
+            sparse_entry = registered
                 .as_ref()
                 .is_some_and(|metadata| metadata.subtile_entry_valid == Some(false));
-            let valid_entry = registered.is_some() && !sparse_entry;
+            valid_entry = registered.is_some() && !sparse_entry;
             let metadata = if valid_entry {
                 registered.expect("valid registered tile metadata")
             } else {
@@ -1943,6 +1960,7 @@ impl ResolvedTerrainGrid {
                 // checks even though LAT may replace Cell+0x38 in between.
                 animation_tile_id = tile_id;
                 animation_sub_tile = current_sub_tile;
+                retained_height_in_pixels = metadata.height_in_pixels;
             }
             let accepts_smudge = valid_entry
                 && tile_id.is_some_and(|tile_id| {
@@ -1960,9 +1978,14 @@ impl ResolvedTerrainGrid {
                 let cell = &mut self.cells[index];
                 if !valid_entry {
                     cell.final_tile_index = 0xFFFF;
-                    cell.final_sub_tile = 0;
+                    if sparse_entry {
+                        cell.final_sub_tile = 0;
+                    }
                 }
                 apply_pristine_load_metadata(cell, &metadata, accepts_smudge, allows_tiberium);
+                // Invalid/sparse paths preserve11D; the valid path updates it
+                // only after its possible automatic Tube constructor.
+                cell.height_in_pixels = snapshot.height_in_pixels;
                 restore_load_base_land(cell);
             }
             base_cliff_eligible = if sparse_entry {
@@ -1984,50 +2007,24 @@ impl ResolvedTerrainGrid {
             self.apply_authored_load_lat_slope(state, index);
         }
 
-        if !early_overlay_branch {
-            // LAT/slope fixup mutates the cell's tile before the automatic Tube
-            // region. Re-resolve the selected final TMP for land/Tube; the
-            // later terrain-Anim predicate deliberately retains the pristine
-            // receiver cached above, as native Recalc does.
-            let post_lat_snapshot = self.cells[index].clone();
-            let final_tile = post_lat_snapshot.final_tile_index;
-            let final_sub_tile = post_lat_snapshot.final_sub_tile;
-            let registered =
-                state.registered_tile_metadata(final_tile, final_sub_tile, &post_lat_snapshot);
-            let sparse_entry = registered
-                .as_ref()
-                .is_some_and(|metadata| metadata.subtile_entry_valid == Some(false));
-            let valid_entry = registered.is_some() && !sparse_entry;
-            let metadata = if valid_entry {
-                registered.expect("valid final registered tile metadata")
-            } else {
-                state.clear_land_metadata()
-            };
-            let final_tile_id = u16::try_from(final_tile).ok();
-            let accepts_smudge = valid_entry
-                && final_tile_id.is_some_and(|tile_id| {
-                    state
-                        .theater_data
-                        .is_some_and(|theater| theater.lookup.is_morphable(tile_id))
-                });
-            let allows_tiberium = valid_entry
-                && final_tile_id.is_some_and(|tile_id| {
-                    state
-                        .theater_data
-                        .is_some_and(|theater| theater.lookup.allows_tiberium(tile_id))
-                });
-            {
-                let cell = &mut self.cells[index];
-                if !valid_entry {
-                    cell.final_tile_index = 0xFFFF;
-                    cell.final_sub_tile = 0;
-                }
-                apply_pristine_load_metadata(cell, &metadata, accepts_smudge, allows_tiberium);
-                restore_load_base_land(cell);
-            }
+        // These are cached current-tile queries, unlike retained native Cell
+        // attributes. CanPlaceTiberium4839C0 and smudge6B5F80 resolve live+38.
+        if let Some(theater) = state.theater_data {
+            let tile = u16::try_from(self.cells[index].final_tile_index).ok();
+            self.cells[index].accepts_smudge =
+                tile.is_some_and(|tile| theater.lookup.is_morphable(tile));
+            self.cells[index].allows_tiberium =
+                tile.is_some_and(|tile| theater.lookup.allows_tiberium(tile));
+        }
 
+        if !early_overlay_branch {
+            // 47D83C/47D8A3 and47D967 use retained EBP after47CA80.
+            // LAT changes+38 and ensures final TMP residency; it does not
+            // replace the pristine land/slope/dimensions receiver. The Tube
+            // predicate separately reads the current tile identity.
             let refreshed_slope = self.cells[index].slope_type;
-            if let Some(flags) = source_flags
+            if valid_entry
+                && let Some(flags) = source_flags
                 && clears_tiberium_on_slope(flags, refreshed_slope)
             {
                 finalized = FinalizedOverlayCell::default();
@@ -2035,9 +2032,19 @@ impl ResolvedTerrainGrid {
             let live_flags = finalized
                 .overlay_id()
                 .and_then(|overlay_id| state.overlay_types.flags(overlay_id));
-            if let Some(flags) = live_flags
-                && let Some(land) = retained_overlay_land(flags, refreshed_slope)
-            {
+            let retained_land = live_flags.and_then(|flags| {
+                if valid_entry {
+                    retained_overlay_land(flags, refreshed_slope)
+                } else if sparse_entry {
+                    // 47D5EF goes directly to the Clear fallback tail.
+                    None
+                } else {
+                    // 47DB22 preserves an ordinary overlay's Land on the
+                    // invalid/sentinel path. Early overlays exited above.
+                    Some(flags.land)
+                }
+            });
+            if let (Some(flags), Some(land)) = (live_flags, retained_land) {
                 apply_load_land_to_cell(
                     &mut self.cells[index],
                     land,
@@ -2105,6 +2112,11 @@ impl ResolvedTerrainGrid {
                         }
                     }
                 }
+
+                if level_override != -1 {
+                    self.cells[index].level = level_override as u8;
+                }
+                self.cells[index].height_in_pixels = retained_height_in_pixels;
 
                 if !state.terrain_anim_is_latched(index)
                     && live_flags.is_none_or(|flags| !uses_early_recalc_land_branch(flags))
@@ -9539,6 +9551,8 @@ NoUseTileLandType=no
             "the first qualifying probe short-circuits the mode-2 scan"
         );
     }
+
+    include!("terrain_recalc_native_tests.rs");
 
     #[test]
     fn authored_load_early_overlay_refreshes_tmp_slope_before_resource_clear() {

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -2010,11 +2010,9 @@ impl ResolvedTerrainGrid {
         // These are cached current-tile queries, unlike retained native Cell
         // attributes. CanPlaceTiberium4839C0 and smudge6B5F80 resolve live+38.
         if let Some(theater) = state.theater_data {
-            let tile = u16::try_from(self.cells[index].final_tile_index).ok();
-            self.cells[index].accepts_smudge =
-                tile.is_some_and(|tile| theater.lookup.is_morphable(tile));
-            self.cells[index].allows_tiberium =
-                tile.is_some_and(|tile| theater.lookup.allows_tiberium(tile));
+            let cell = &mut self.cells[index];
+            (cell.accepts_smudge, cell.allows_tiberium) =
+                current_tile_permissions(&theater.lookup, cell.final_tile_index);
         }
 
         if !early_overlay_branch {
@@ -4690,6 +4688,21 @@ fn restore_load_base_land(cell: &mut ResolvedTerrainCell) {
     );
     cell.is_rough = cell.base_land_type == LandType::Rough.as_index();
     cell.is_road = cell.base_land_type == LandType::Road.as_index();
+}
+
+/// Current Cell+38 queries, separate from Recalc's retained pristine metadata.
+/// Native smudge6B601A..6B603A falls back to tile0 for an invalid signed index;
+/// CanPlaceTiberium4839C0..4839E9 admits that index at its final tile gate.
+/// Other placement gates are outside this projection. Original-block witnesses:
+/// tools/spatial_oracle/terrain_tile_permissions.
+fn current_tile_permissions(lookup: &TilesetLookup, tile: i32) -> (bool, bool) {
+    if tile < 0 || tile as usize >= lookup.len() {
+        (lookup.is_morphable(0), true)
+    } else {
+        // The registry admits at most65535 slots; compare before narrowing.
+        let tile = tile as u16;
+        (lookup.is_morphable(tile), lookup.allows_tiberium(tile))
+    }
 }
 
 fn apply_pristine_load_metadata(

--- a/src/map/terrain_recalc_native_tests.rs
+++ b/src/map/terrain_recalc_native_tests.rs
@@ -1,0 +1,117 @@
+// Included inside resolved_terrain::tests to share its real TMP/loader fixture.
+// Native outputs: tools/spatial_oracle/terrain_recalc, original47D2B0 and callees.
+
+#[test]
+fn recalc_pristine_metadata_and_level_override_match_original_instructions() {
+    let corpus: serde_json::Value = serde_json::from_str(include_str!(
+        "../../tools/spatial_oracle/terrain_recalc.json"
+    ))
+    .unwrap();
+    let cases = corpus["cases"].as_array().unwrap();
+    assert_eq!(cases.len(), 10);
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let flag = |key: &str| case[key].as_bool().unwrap();
+        let number = |key: &str| case[key].as_i64().unwrap();
+        let mut theater = synthetic_theater_from_ini(
+            b"[TileSet0000]\nTilesInSet=1\nFileName=other\nSetName=Other\n\
+              Morphable=no\nAllowTiberium=no\n\
+              [TileSet0001]\nTilesInSet=1\nFileName=source\nSetName=Source\n\
+              Morphable=yes\nAllowTiberium=yes\n",
+        );
+        let mut source = gsi_04_02_last_tiles_tmp_bytes(11, [0; 3], [0; 3]);
+        let mut other = source.clone();
+        if flag("lat") {
+            other[61] = 15;
+            other[62] = 4;
+            other[12..16].copy_from_slice(&34u32.to_le_bytes());
+            other.resize(72 + 8 * 34 / 2, 1);
+            theater.rmg_tiles.ramp_base = Some(1);
+        }
+        if flag("sparse") {
+            source[16..20].copy_from_slice(&0u32.to_le_bytes());
+            other = source.clone();
+        }
+        let (_directory, assets) = gsi_04_02_asset_manager_with_loose_tmps(&[
+            ("source01.tem", &source),
+            ("other01.tem", &other),
+        ]);
+        let ini = IniFile::from_str(
+            "[Clear]\nWheel=100%\n[Road]\nWheel=100%\n[Rock]\nWheel=0%\n\
+             [Tiberium]\nWheel=0%\n\
+             [OverlayTypes]\n0=EARLY\n1=ROAD\n2=RESOURCE\n\
+             [EARLY]\nLand=Road\nNoUseTileLandType=yes\n\
+             [ROAD]\nLand=Road\nNoUseTileLandType=no\n\
+             [RESOURCE]\nLand=Tiberium\nTiberium=yes\nNoUseTileLandType=no\n",
+        );
+        let rules = TerrainRules::from_ini(&ini);
+        let registry = OverlayTypeRegistry::from_ini(&ini, None);
+        let mut map = make_map(Vec::new(), Vec::new(), Vec::new());
+        map.header.width = 16;
+        map.header.height = 16;
+        map.header.local_left = 0;
+        map.header.local_top = 0;
+        map.header.local_width = 16;
+        map.header.local_height = 16;
+        let cells = (0..33)
+            .flat_map(|y| (0..33).map(move |x| make_test_cell(x, y)))
+            .collect();
+        let mut grid = ResolvedTerrainGrid::from_cells(33, 33, cells);
+        let index = 16 * 33 + 16;
+        grid.cells[index].final_tile_index = if flag("invalid") {
+            2
+        } else {
+            i32::from(flag("lat"))
+        };
+        grid.cells[index].final_sub_tile = number("input_subtile") as u8;
+        grid.cells[index].level = 4;
+        grid.cells[index].height_in_pixels = 88;
+        let mut state = LoadCellRecalcState::for_authored_load(
+            &map,
+            &theater,
+            &assets,
+            &rules,
+            &registry,
+            flag("lat"),
+            0,
+            grid.cells.len(),
+        );
+        let overlay = if flag("early") {
+            FinalizedOverlayCell::from_parts(0, 0)
+        } else {
+            match case["overlay_land"].as_i64() {
+                Some(1) => FinalizedOverlayCell::from_parts(1, 0),
+                Some(5) => FinalizedOverlayCell::from_parts(2, 0),
+                None => FinalizedOverlayCell::default(),
+                other => panic!("unexpected fixture overlay land {other:?}"),
+            }
+        };
+        grid.recalc_cell_attributes(
+            &mut state,
+            index,
+            overlay,
+            number("level_override") as i32,
+            &mut LoadRecalcTestEffects::default(),
+        )
+        .unwrap();
+        let cell = &grid.cells[index];
+        if flag("lat") {
+            assert!(!cell.accepts_smudge, "{name}: final-tile Morphable query");
+            assert!(
+                !cell.allows_tiberium,
+                "{name}: final-tile AllowTiberium query"
+            );
+        }
+        for (field, actual) in [
+            ("tile", i64::from(cell.final_tile_index)),
+            ("subtile", i64::from(cell.final_sub_tile)),
+            ("level", i64::from(cell.level)),
+            ("slope", i64::from(cell.slope_type)),
+            ("height", i64::from(cell.height_in_pixels)),
+            ("land", i64::from(cell.yr_cell_land_type)),
+            ("zone", i64::from(cell.zone_type)),
+        ] {
+            assert_eq!(actual, number(field), "{name}: {field}");
+        }
+    }
+}

--- a/src/map/terrain_recalc_native_tests.rs
+++ b/src/map/terrain_recalc_native_tests.rs
@@ -102,6 +102,10 @@ fn recalc_pristine_metadata_and_level_override_match_original_instructions() {
                 "{name}: final-tile AllowTiberium query"
             );
         }
+        if flag("invalid") || flag("sparse") {
+            assert!(!cell.accepts_smudge, "{name}: tile0 Morphable fallback");
+            assert!(cell.allows_tiberium, "{name}: invalid final-tile gate");
+        }
         for (field, actual) in [
             ("tile", i64::from(cell.final_tile_index)),
             ("subtile", i64::from(cell.final_sub_tile)),
@@ -113,5 +117,39 @@ fn recalc_pristine_metadata_and_level_override_match_original_instructions() {
         ] {
             assert_eq!(actual, number(field), "{name}: {field}");
         }
+    }
+}
+
+#[test]
+fn current_tile_permission_queries_match_original_instruction_blocks() {
+    let corpus: serde_json::Value = serde_json::from_str(include_str!(
+        "../../tools/spatial_oracle/terrain_tile_permissions.json"
+    ))
+    .unwrap();
+    for case in corpus["cases"].as_array().unwrap() {
+        let tile = case["tile"].as_i64().unwrap() as i32;
+        let tile0 = case["tile0_permission"].as_bool().unwrap();
+        let yes_no = |value| if value { "yes" } else { "no" };
+        let ini = format!(
+            "[TileSet0000]\nTilesInSet=1\nFileName=zero\n\
+             Morphable={}\nAllowTiberium={}\n\
+             [TileSet0001]\nTilesInSet=1\nFileName=one\n\
+             Morphable={}\nAllowTiberium={}\n",
+            yes_no(tile0),
+            yes_no(tile0),
+            yes_no(!tile0),
+            yes_no(!tile0),
+        );
+        let theater = synthetic_theater_from_ini(ini.as_bytes());
+        assert_eq!(theater.lookup.len(), 2);
+        let actual = current_tile_permissions(&theater.lookup, tile);
+        assert_eq!(
+            actual,
+            (
+                case["smudge"].as_bool().unwrap(),
+                case["tiberium"].as_bool().unwrap()
+            ),
+            "tile={tile}, tile0_permission={tile0}"
+        );
     }
 }

--- a/tools/spatial_oracle/terrain_recalc.json
+++ b/tools/spatial_oracle/terrain_recalc.json
@@ -1,0 +1,244 @@
+{
+  "cases": [
+    {
+      "early": false,
+      "height": -1,
+      "input_subtile": 0,
+      "invalid": false,
+      "land": 1,
+      "lat": false,
+      "level": 4,
+      "level_cache": [
+        4
+      ],
+      "level_override": -1,
+      "name": "valid_preserves_level",
+      "overlay_land": null,
+      "slope": 0,
+      "sparse": false,
+      "subtile": 0,
+      "tile": 0,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        4
+      ]
+    },
+    {
+      "early": false,
+      "height": -1,
+      "input_subtile": 0,
+      "invalid": false,
+      "land": 1,
+      "lat": false,
+      "level": 2,
+      "level_cache": [
+        2
+      ],
+      "level_override": 2,
+      "name": "valid_replaces_level",
+      "overlay_land": null,
+      "slope": 0,
+      "sparse": false,
+      "subtile": 0,
+      "tile": 0,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        2
+      ]
+    },
+    {
+      "early": false,
+      "height": -1,
+      "input_subtile": 0,
+      "invalid": false,
+      "land": 1,
+      "lat": false,
+      "level": 5,
+      "level_cache": [
+        5
+      ],
+      "level_override": 261,
+      "name": "valid_level_low_byte",
+      "overlay_land": null,
+      "slope": 0,
+      "sparse": false,
+      "subtile": 0,
+      "tile": 0,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        5
+      ]
+    },
+    {
+      "early": false,
+      "height": -1,
+      "input_subtile": 0,
+      "invalid": false,
+      "land": 1,
+      "lat": false,
+      "level": 254,
+      "level_cache": [
+        254
+      ],
+      "level_override": -2,
+      "name": "valid_negative_level_low_byte",
+      "overlay_land": null,
+      "slope": 0,
+      "sparse": false,
+      "subtile": 0,
+      "tile": 0,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        254
+      ]
+    },
+    {
+      "early": false,
+      "height": -1,
+      "input_subtile": 0,
+      "invalid": false,
+      "land": 1,
+      "lat": true,
+      "level": 2,
+      "level_cache": [
+        2
+      ],
+      "level_override": 2,
+      "name": "retains_pristine_after_lat_changes_identity",
+      "overlay_land": null,
+      "slope": 0,
+      "sparse": false,
+      "subtile": 0,
+      "tile": 0,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        2
+      ]
+    },
+    {
+      "early": false,
+      "height": 88,
+      "input_subtile": 7,
+      "invalid": true,
+      "land": 0,
+      "lat": false,
+      "level": 4,
+      "level_cache": [
+        4
+      ],
+      "level_override": 2,
+      "name": "invalid_tile_does_not_override_level",
+      "overlay_land": null,
+      "slope": 0,
+      "sparse": false,
+      "subtile": 7,
+      "tile": 65535,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        4
+      ]
+    },
+    {
+      "early": false,
+      "height": 88,
+      "input_subtile": 0,
+      "invalid": false,
+      "land": 0,
+      "lat": false,
+      "level": 4,
+      "level_cache": [
+        4
+      ],
+      "level_override": 2,
+      "name": "sparse_subtile_does_not_override_level",
+      "overlay_land": null,
+      "slope": 0,
+      "sparse": true,
+      "subtile": 0,
+      "tile": 65535,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        4
+      ]
+    },
+    {
+      "early": true,
+      "height": 88,
+      "input_subtile": 0,
+      "invalid": false,
+      "land": 1,
+      "lat": false,
+      "level": 4,
+      "level_cache": [
+        4
+      ],
+      "level_override": 2,
+      "name": "early_overlay_does_not_override_level",
+      "overlay_land": null,
+      "slope": 0,
+      "sparse": false,
+      "subtile": 0,
+      "tile": 0,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        4
+      ]
+    },
+    {
+      "early": false,
+      "height": 88,
+      "input_subtile": 7,
+      "invalid": true,
+      "land": 1,
+      "lat": false,
+      "level": 4,
+      "level_cache": [
+        4
+      ],
+      "level_override": 2,
+      "name": "invalid_tile_retains_ordinary_overlay_land",
+      "overlay_land": 1,
+      "slope": 0,
+      "sparse": false,
+      "subtile": 7,
+      "tile": 65535,
+      "zone": 0,
+      "zone_cache": [
+        0,
+        4
+      ]
+    },
+    {
+      "early": false,
+      "height": 88,
+      "input_subtile": 0,
+      "invalid": false,
+      "land": 0,
+      "lat": false,
+      "level": 4,
+      "level_cache": [
+        4
+      ],
+      "level_override": 2,
+      "name": "sparse_subtile_discards_resource_land",
+      "overlay_land": 5,
+      "slope": 0,
+      "sparse": true,
+      "subtile": 0,
+      "tile": 65535,
+      "zone": 6,
+      "zone_cache": [
+        6,
+        4
+      ]
+    }
+  ]
+}

--- a/tools/spatial_oracle/terrain_recalc.meta.json
+++ b/tools/spatial_oracle/terrain_recalc.meta.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "Ten synthetic47D2B0 cases for retained pristine metadata, conditional level override and distinct invalid/sparse overlay branches",
+  "assumptions": [
+    "Supplied single real cell at16,16 in a16x16 map; resident synthetic pristine TMP and optional Road or resource overlay",
+    "TMP geometry1x1,8x4 pixels, raw land11, template height3, slope0; file loading and pointer relocation excluded",
+    "Original vtable7ECC48 resolves544CB0; actual entry validation, slope, land and dimension getters execute",
+    "LAT globals supplied-1, except synthetic RampBase1; flat fallback changes tile1 to tile0 (Rock,slope4,pixelheight34) while attributes retain tile1 Road/flat/pixelheight4",
+    "CliffBack0, no objects, no shadow, no terrain animation, no Tube land; supplied Clear/Road Wheel1.0 and Tiberium Wheel0.0",
+    "Inputs are branch witnesses, not retail map reachability; no full Recalc, bridge, draw or navigation-connectivity claim"
+  ],
+  "substitutions": [],
+  "entry_points": {
+    "recalc": "0x0047D2B0",
+    "lat": "0x0047CA80",
+    "zone": "0x00483C80",
+    "entry": "0x00544C20",
+    "tmp": "0x00544CB0",
+    "slope": "0x005471B0",
+    "land": "0x00544BE0",
+    "dimensions": "0x00547150"
+  },
+  "payload_sha256": "0ada0c3804fbbf9656aad01707679c05562cb398f9edec42607ba5b6132232c2"
+}

--- a/tools/spatial_oracle/terrain_recalc.py
+++ b/tools/spatial_oracle/terrain_recalc.py
@@ -1,0 +1,111 @@
+"""Original47D2B0 retained-TMP and level-override branch comparisons.
+
+Synthetic resident tile/overlay/map inputs isolate the Recalc prerequisite for
+runtime bridge replacement. No native instructions or calls are substituted.
+This is not native loading, full Recalc coverage, or a retail bridge witness.
+"""
+from pathlib import Path
+import struct
+
+from tools.native_oracle import SCRATCH, call, finish_vectors, provenance
+from tools.spatial_oracle.map_queries import dwords, packed
+
+MAP, TABLE = 0x87F7E8, 0xC00000
+CELL, HEAD, TMP = SCRATCH + 0x1000, SCRATCH + 0x2000, SCRATCH + 0x2800
+TILES, OVERLAYS, OVERLAY = SCRATCH + 0x3000, SCRATCH + 0x3400, SCRATCH + 0x3800
+RULES, ZONES, LEVELS = SCRATCH + 0x4000, SCRATCH + 0x5000, SCRATCH + 0x8000
+LAT_GLOBALS = (0xAA1090, 0xABAD28, 0xAA1134, 0xAA0E24, 0xAA0748,
+               0xAA10A8, 0xAA10A4, 0xABBEC8, 0xAA0E20, 0xAA1058,
+               0xABC1D8, 0xABC2B8, 0xABB104, 0xAA0E18, 0xABC2B0)
+
+
+def native_case(name, override, *, lat=False, invalid=False, sparse=False, early=False,
+                overlay_land=None):
+    table = bytearray(0x100000)
+    struct.pack_into('<I', table, (16 * 512 + 16) * 4, CELL)
+    # Same explicit tiny TMP geometry used by the Rust loader fixture: one
+    # 8x4 subimage, raw terrain11, height3, flat slope. Native runtime pointers
+    # are supplied in place of file offsets; TMP loading is outside this case.
+    tmp = bytearray(88)
+    struct.pack_into('<5I', tmp, 0, 1, 1, 8, 4, 0 if sparse else TMP + 20)
+    tmp[60:63] = bytes((3, 11, 0))
+    other_tmp = bytearray(tmp)
+    other_tmp[61:63] = bytes((15, 4))
+    struct.pack_into('<I', other_tmp, 12, 34)
+    writes = {
+        TABLE: bytes(table), MAP + 0x13C: dwords(TABLE, 0x40000),
+        MAP + 0xF4: dwords(16, 16, 0, 0, 16, 16),
+        MAP + 0x68: dwords(ZONES, 33 * 33, LEVELS),
+        CELL + 0x24: packed(16, 16), CELL + 0x38: dwords(2 if invalid else int(lat)),
+        CELL + 0x44: dwords(0 if early or overlay_land is not None else -1), CELL + 0xEC: dwords(3),
+        CELL + 0x11A: bytes((7 if invalid else 0, 4, 0, 88)),
+        HEAD: dwords(0x7ECC48), HEAD + 0xA4: dwords(TMP),
+        HEAD + 0x2C8: dwords(-1), HEAD + 0x2D4: dwords(-1), TMP: bytes(tmp),
+        0xA8ED2C: dwords(TILES), 0xA8ED38: dwords(2), TILES: dwords(HEAD, HEAD),
+        0xA83D84: dwords(OVERLAYS), OVERLAYS: dwords(OVERLAY),
+        OVERLAY + 0x298: dwords(1 if overlay_land is None else overlay_land),
+        OVERLAY + 0x2AC: bytes((int(early),)),
+        OVERLAY + 0x2A9: bytes((int(overlay_land == 5),)),
+        0x8871E0: dwords(RULES), RULES + 0x664: b'\0',
+        0x89EA48: struct.pack('<f', 1.0), 0x89EA48 + 36: struct.pack('<f', 1.0),
+        0x89EA48 + 5 * 36: struct.pack('<f', 0.0),
+        **{address: dwords(-1) for address in LAT_GLOBALS},
+    }
+    if lat:
+        writes[0xABC1D8] = dwords(1)
+        writes[TILES] = dwords(HEAD + 0x400, HEAD)
+        writes[HEAD + 0x400] = dwords(0x7ECC48)
+        writes[HEAD + 0x400 + 0xA4] = dwords(TMP + 0x200)
+        struct.pack_into('<I', other_tmp, 16, TMP + 0x200 + 20)
+        writes[TMP + 0x200] = bytes(other_tmp)
+    required = [0x483C80]
+    if not invalid and not sparse:
+        required += [0x5471B0, 0x544CB0, 0x47CA80]
+        if not early:
+            required += [0x547150, 0x544BE0]
+    output = call(0x47D2B0, ecx=CELL, stack_args=[override & 0xFFFFFFFF],
+                  writes=writes, dumps={'cell': (CELL, 0x144),
+                                       'zone': (ZONES + (16 * 33 + 16) * 4, 2),
+                                       'level': (LEVELS + (16 * 33 + 16) * 10 + 8, 1)},
+                  timeout_instr=10000, required_addresses=required)
+    result = bytes.fromhex(output['dumps']['cell'])
+    return dict(name=name, level_override=override, lat=lat, invalid=invalid,
+                input_subtile=7 if invalid else 0,
+                sparse=sparse, early=early, overlay_land=overlay_land,
+                tile=struct.unpack_from('<i', result, 0x38)[0],
+                land=struct.unpack_from('<i', result, 0xEC)[0],
+                zone=struct.unpack_from('<i', result, 0x4C)[0],
+                subtile=result[0x11A], level=result[0x11B], slope=result[0x11C],
+                height=struct.unpack_from('<b', result, 0x11D)[0],
+                zone_cache=list(bytes.fromhex(output['dumps']['zone'])),
+                level_cache=list(bytes.fromhex(output['dumps']['level'])))
+
+
+def cases():
+    return {'cases': [
+        native_case('valid_preserves_level', -1),
+        native_case('valid_replaces_level', 2),
+        native_case('valid_level_low_byte', 261),
+        native_case('valid_negative_level_low_byte', -2),
+        native_case('retains_pristine_after_lat_changes_identity', 2, lat=True),
+        native_case('invalid_tile_does_not_override_level', 2, invalid=True),
+        native_case('sparse_subtile_does_not_override_level', 2, sparse=True),
+        native_case('early_overlay_does_not_override_level', 2, early=True),
+        native_case('invalid_tile_retains_ordinary_overlay_land', 2, invalid=True, overlay_land=1),
+        native_case('sparse_subtile_discards_resource_land', 2, sparse=True, overlay_land=5),
+    ]}
+
+
+if __name__ == '__main__':
+    finish_vectors(cases, Path(__file__).with_suffix('.json'), provenance=lambda: provenance(
+        scope='Ten synthetic47D2B0 cases for retained pristine metadata, conditional level override and distinct invalid/sparse overlay branches',
+        assumptions=[
+            'Supplied single real cell at16,16 in a16x16 map; resident synthetic pristine TMP and optional Road or resource overlay',
+            'TMP geometry1x1,8x4 pixels, raw land11, template height3, slope0; file loading and pointer relocation excluded',
+            'Original vtable7ECC48 resolves544CB0; actual entry validation, slope, land and dimension getters execute',
+            'LAT globals supplied-1, except synthetic RampBase1; flat fallback changes tile1 to tile0 (Rock,slope4,pixelheight34) while attributes retain tile1 Road/flat/pixelheight4',
+            'CliffBack0, no objects, no shadow, no terrain animation, no Tube land; supplied Clear/Road Wheel1.0 and Tiberium Wheel0.0',
+            'Inputs are branch witnesses, not retail map reachability; no full Recalc, bridge, draw or navigation-connectivity claim',
+        ], substitutions=[], entry_points={'recalc': 0x47D2B0, 'lat': 0x47CA80,
+          'zone': 0x483C80, 'entry': 0x544C20, 'tmp': 0x544CB0,
+          'slope': 0x5471B0, 'land': 0x544BE0, 'dimensions': 0x547150}))

--- a/tools/spatial_oracle/terrain_tile_permissions.json
+++ b/tools/spatial_oracle/terrain_tile_permissions.json
@@ -1,0 +1,100 @@
+{
+  "cases": [
+    {
+      "smudge": false,
+      "tiberium": true,
+      "tile": -2147483648,
+      "tile0_permission": false
+    },
+    {
+      "smudge": false,
+      "tiberium": true,
+      "tile": -1,
+      "tile0_permission": false
+    },
+    {
+      "smudge": false,
+      "tiberium": false,
+      "tile": 0,
+      "tile0_permission": false
+    },
+    {
+      "smudge": true,
+      "tiberium": true,
+      "tile": 1,
+      "tile0_permission": false
+    },
+    {
+      "smudge": false,
+      "tiberium": true,
+      "tile": 2,
+      "tile0_permission": false
+    },
+    {
+      "smudge": false,
+      "tiberium": true,
+      "tile": 65535,
+      "tile0_permission": false
+    },
+    {
+      "smudge": false,
+      "tiberium": true,
+      "tile": 65536,
+      "tile0_permission": false
+    },
+    {
+      "smudge": false,
+      "tiberium": true,
+      "tile": 2147483647,
+      "tile0_permission": false
+    },
+    {
+      "smudge": true,
+      "tiberium": true,
+      "tile": -2147483648,
+      "tile0_permission": true
+    },
+    {
+      "smudge": true,
+      "tiberium": true,
+      "tile": -1,
+      "tile0_permission": true
+    },
+    {
+      "smudge": true,
+      "tiberium": true,
+      "tile": 0,
+      "tile0_permission": true
+    },
+    {
+      "smudge": false,
+      "tiberium": false,
+      "tile": 1,
+      "tile0_permission": true
+    },
+    {
+      "smudge": true,
+      "tiberium": true,
+      "tile": 2,
+      "tile0_permission": true
+    },
+    {
+      "smudge": true,
+      "tiberium": true,
+      "tile": 65535,
+      "tile0_permission": true
+    },
+    {
+      "smudge": true,
+      "tiberium": true,
+      "tile": 65536,
+      "tile0_permission": true
+    },
+    {
+      "smudge": true,
+      "tiberium": true,
+      "tile": 2147483647,
+      "tile0_permission": true
+    }
+  ]
+}

--- a/tools/spatial_oracle/terrain_tile_permissions.meta.json
+++ b/tools/spatial_oracle/terrain_tile_permissions.meta.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "Sixteen synthetic original-block witnesses for current-tile Morphable and AllowTiberium queries",
+  "assumptions": [
+    "Supplied two-entry registry with opposite permission bits; count2 and Cell+38 span signed and narrowing boundaries",
+    "Smudge starts at6B601A with ESI=Cell and stops before TEST AL at6B603A",
+    "Tiberium starts at4839C0 with EDI=Cell and stops before accepted4839E2 or rejected4839E9 return sequence",
+    "Prior placement gates are assumed passed; later smudge gates and complete placement behavior are excluded",
+    "Registry construction and stock reachability are outside these synthetic boundary witnesses"
+  ],
+  "substitutions": [],
+  "entry_points": {
+    "smudge_tile_gate": "0x006B601A",
+    "tiberium_tile_gate": "0x004839C0"
+  },
+  "payload_sha256": "940b30c81d6a04b445c6f5afc0ca4bf445bf6de49ba0fdd8f03c9e018c8e1de5"
+}

--- a/tools/spatial_oracle/terrain_tile_permissions.py
+++ b/tools/spatial_oracle/terrain_tile_permissions.py
@@ -1,0 +1,56 @@
+"""Original signed current-tile permission gates, not complete placement checks.
+
+Supplied two-entry registry varies both permission bits. Execute original blocks
+up to their next gate/return boundary without changing executable instructions.
+"""
+from pathlib import Path
+
+from unicorn import Uc, UC_ARCH_X86, UC_MODE_32
+from unicorn.x86_const import UC_X86_REG_EAX, UC_X86_REG_EDI, UC_X86_REG_ESI
+
+from tools.native_oracle import SCRATCH, load_image, run_checked, finish_vectors, provenance
+from tools.spatial_oracle.map_queries import dwords
+
+CELL, TILES, HEAD0, HEAD1 = (SCRATCH + offset for offset in (0, 0x200, 0x400, 0x800))
+
+
+def native_case(tile, tile0_permission):
+    uc = Uc(UC_ARCH_X86, UC_MODE_32)
+    load_image(uc)
+    uc.mem_map(SCRATCH, 0x1000)
+    for address, blob in {
+        CELL + 0x38: dwords(tile),
+        0xA8ED2C: dwords(TILES), 0xA8ED38: dwords(2),
+        TILES: dwords(HEAD0, HEAD1),
+        HEAD0 + 0x2E0: bytes((tile0_permission,)),
+        HEAD0 + 0x306: bytes((tile0_permission,)),
+        HEAD1 + 0x2E0: bytes((not tile0_permission,)),
+        HEAD1 + 0x306: bytes((not tile0_permission,)),
+    }.items():
+        uc.mem_write(address, blob)
+    uc.reg_write(UC_X86_REG_ESI, CELL)
+    run_checked(uc, 0x6B601A, 0x6B603A, count=64, required_addresses=[0x6B6034])
+    smudge = bool(uc.reg_read(UC_X86_REG_EAX) & 0xFF)
+    uc.reg_write(UC_X86_REG_EDI, CELL)
+    boundary = run_checked(uc, 0x4839C0, (0x4839E2, 0x4839E9), count=64)
+    return dict(tile=tile, tile0_permission=tile0_permission,
+                smudge=smudge, tiberium=boundary == 0x4839E2)
+
+
+def cases():
+    return {'cases': [native_case(tile, permission)
+                      for permission in (False, True)
+                      for tile in (-0x80000000, -1, 0, 1, 2, 0xFFFF, 0x10000, 0x7FFFFFFF)]}
+
+
+if __name__ == '__main__':
+    finish_vectors(cases, Path(__file__).with_suffix('.json'), provenance=lambda: provenance(
+        scope='Sixteen synthetic original-block witnesses for current-tile Morphable and AllowTiberium queries',
+        assumptions=[
+            'Supplied two-entry registry with opposite permission bits; count2 and Cell+38 span signed and narrowing boundaries',
+            'Smudge starts at6B601A with ESI=Cell and stops before TEST AL at6B603A',
+            'Tiberium starts at4839C0 with EDI=Cell and stops before accepted4839E2 or rejected4839E9 return sequence',
+            'Prior placement gates are assumed passed; later smudge gates and complete placement behavior are excluded',
+            'Registry construction and stock reachability are outside these synthetic boundary witnesses',
+        ], substitutions=[], entry_points={'smudge_tile_gate': 0x6B601A,
+                                            'tiberium_tile_gate': 0x4839C0}))


### PR DESCRIPTION
When automatic terrain adjustment (LAT) changes a cell's tile, recalculation must still derive its land, slope and dimensions from the original pristine TMP receiver. Preserve that receiver, match the distinct invalid/sparse fallbacks, and refresh ore/smudge permissions from the final tile using the native invalid-index rules. Also correct the slope-zero fallback to DWORD arithmetic and expose the conditional level-override entry; ordinary authored loading continues to pass -1.

This is a complete authored-load prerequisite with production callers. Live bridge-ramp replacement remains on its separate preserved branch; this PR does not close a Phase 3 row or claim complete Recalc/presentation parity.

Evidence: original active-retail `gamemd.exe` Recalc `47D2B0`, LAT `47CA80`/`47D1C0`, and permission gates `4839C0`/`6B601A`. The committed harnesses record binary identity and coverage limits: ten original Recalc branch witnesses without substitutions, plus sixteen original permission-block witnesses. Both comparisons passed independently. Fresh read-only review passed the isolated candidate and confirmed its authored-load callers.

Validation on `1914f8983c3de0ac63dfe67778704720c4eff6cb`:

- `cargo test -p vera20k --lib`: 8,684 passed, 0 failed, 121 ignored.
- `cargo clippy -p vera20k --lib`: passed (exit 0; 1,147 existing warnings).
- Both native harness comparisons passed; candidate matches the independently reviewed files.
