### PR TITLE
Preserve saved-map defaults and invalidate failed previews

### DIFF
--- a/docs/plans/2026-09-12-retail-shells-acceptance.md
+++ b/docs/plans/2026-09-12-retail-shells-acceptance.md
@@ -1,0 +1,71 @@
+# Retail shell acceptance
+
+The requested scope is **all player-facing VERA20k shells**, starting with
+Skirmish. The July [stock-skirmish design](2026-07-25-exact-stock-skirmish-shell-ui-design.md)
+and `tools/exact_shell_ui_matrix` cover only a subset. They cannot certify this
+whole task. Correct existing behavior is retained; missing or unproven required
+behavior remains open. The 20,000-unit / 30-player scale exception in ENGINE.md
+remains explicit; retail-size comparisons do not certify the extended roster.
+
+## Acceptance for every reachable route
+
+1. Establish active retail callers, resource/control identities, inputs, state
+   writers and exit/return paths. Recheck research against `gamemd.exe` and data;
+   a resource or inherited function's existence does not prove reachability.
+2. Compare geometry, composition order, assets/frames, palettes, font/CSF text,
+   cursor, focus, disabled/pressed/hover states and help. Cover 640x480, 800x600,
+   1024x768 and further distinct active sizing branches. Capture resolution,
+   crop, scaling, color space, cursor and animation phase must be comparable.
+3. Exercise mouse press/release/capture, dragging outside, keyboard default and
+   cancel, tab order, editing/selection/caret, list/combo scrolling, and modal
+   blocking. Check sound events and transitions as well as steady frames.
+4. Validate defaults, persisted state, commit/cancel, errors, child return,
+   repeated entry, teardown and handoff through the production path. Preserve
+   one authoritative settings/selection/result owner across these operations.
+5. Distinguish native behavior established, named Rust regressions tested, and
+   parity demonstrated. Record native-derived comparisons with binary/data
+   identity and bounded coverage. Tests or plausible art alone cannot close
+   visual acceptance. Sampled comparisons do not certify unsampled states.
+
+## Required family inventory
+
+This is a discovery/acceptance map, not a completion ledger. Expand it when an
+active caller exposes another route; exclude only with recorded evidence.
+
+| Family | Required journey and children | Current implementation entry points |
+| --- | --- | --- |
+| Skirmish first | Main menu → Single Player → setup; roster/name/country/color/team/AI, settings, map/mode chooser, cooperative selection, validation, RMG and saved-seed children; Back/reentry; Start → loading → first tactical frame | `src/app/shell_skirmish.rs`, `shell_random_map.rs`, `src/ui/skirmish_shell/`, `src/app/frontend/skirmish_shell_render.rs` |
+| Startup/main menu | Startup presentation, main menu, Single Player, navigation/help, website action, exit confirmation/shutdown | `src/app/shell_main_menu.rs`, `src/ui/main_menu_shell/`, `single_player_shell/` |
+| Campaign | Choice/difficulty, launch, active briefing/media checks, progression and return | `src/ui/main_menu_dialogs.rs`, `src/app/shell_main_menu.rs` |
+| Saved games | Single Player Load and in-game Load/Save/Delete; metadata, edit, confirmation/error, restoration and return | `src/app/persistence/save_load_panel.rs` |
+| Launcher options | Parent settings, previews, persistence; Keyboard and Network children; child return | `src/app/shell_main_menu.rs`, `src/ui/main_menu_dialogs.rs` |
+| Movies/credits | Submenu, movie list, playback, credits, cancellation and return | `src/ui/main_menu_dialogs.rs`, `src/app/shell_main_menu.rs` |
+| LAN/network | Settings/identity, browse/host/join, lobby, map/options/readiness/chat, Start, disconnect/cancel/error and reentry | Main-menu dispatch; active native route inventory still required |
+| Westwood Online | Reachable retail entry/settings/login, connection/error/cancel and subsequent active dialogs | Main-menu dispatch; native local behavior must be separated from external service availability |
+| In-game shell | Resume, Abort/Leave/Restart/Observe by mode, Game Controls, Keyboard, Sound, save children, objectives/mission restatement/diplomacy where active | `src/ui/pause_menu.rs`, `src/app/input/in_game_options.rs`, `dispatch.rs` |
+| Results/return | Skirmish score, applicable campaign/cooperative/network results, Continue, media/progression, shell reconstruction | `src/ui/score_shell.rs`, `src/app/frontend/score_shell_render.rs` |
+| Common children | Reachable confirmations, errors, media checks and progress; mode/side composition, focus and default/cancel restoration | `src/ui/shell/` plus each owning route |
+
+The initial independent read-only audit found log-only or presentation-only
+actions in campaign, movies, network/online, website and options children, and
+egui substitutes for several menus. Source must be rechecked when those families
+are reached. Their presence in this inventory is not a parity claim.
+
+## Delivery and final audit
+
+Use coherent behavior increments with native evidence, implementation, production
+integration and appropriate regressions. Refactor affected ownership when it
+removes duplicate authority or makes a proven second consumer correct; avoid a
+generic UI rewrite merely to replace a rendering toolkit.
+
+After each increment a fresh independent read-only critic inspects original
+evidence, design, diff and actual validation, with freedom to challenge omitted
+scope. Correct confirmed findings until a scoped pass. Preserve independently
+confirmed Ghidra labels/comments, save and read them back, update relevant docs,
+then commit, publish and merge under the user's authority. Revalidate affected
+neighbors after shared changes and integration conflicts.
+
+Finish only after the complete reachable route graph has been checked against
+this inventory, including error/cancel/return paths, whole-scope validation and
+an independent omission/regression audit. Keep one current local checkpoint for
+unfinished work; do not convert partial progress into a completion claim.

--- a/docs/research/skirmish-ui/2026-09-12-saved-seed-load-regeneration.md
+++ b/docs/research/skirmish-ui/2026-09-12-saved-seed-load-regeneration.md
@@ -1,0 +1,92 @@
+# Saved-seed Load to preview generation
+
+Scope: current-record defaults in RMG saved-seed loading and generation failure ownership.
+This is not saved-seed browser or shell parity certification. Button availability,
+catalog eligibility, save naming/confirmation, keyboard handling and full visual
+comparison remain required work under the [shell acceptance](../../plans/2026-09-12-retail-shells-acceptance.md).
+
+## Native behavior established
+
+Live Ghidra reads on 2026-09-12 target `/gamemd.exe`, image base `0x00400000`,
+x86 little endian. Retail executable SHA-256:
+`1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c`.
+
+- `RandomMapSetupDialog__Proc` (`0x00596300`) handles Load `0x6C2` on the
+  active Create Random Map dialog. At `0x0059694A` it binds ECX to the live
+  MapSeed record `0x00ABDFD8`, then calls the Load modal at `0x0059694F`.
+- On success `0x00596963` clears byte `0x0082B030`; `0x0059697C` posts
+  `WM_COMMAND/0x620` (Generate). At `0x005969B1` the handler calls
+  `SyncControlsFromOptions` (`0x00596E50`) before the posted action runs.
+- The Generate branch consumes the latch and calls `SyncOptionsFromControls`
+  (`0x00596C70`). When the compared control values remain unchanged, derived fields are not
+  rerolled. This condition matters: MapType 0 is absent from the rebuilt combo;
+  unlisted theaters are absent too. The custom combo (`0x00617250`) returns
+  `-1` for unselected item data, so the subsequent sync marks the record dirty
+  and rerolls before clamping. Do not implement an unconditional no-reroll load.
+  That sync uses one Size control for both width and height and
+  clamps the options. Generate replaces Description with localized
+  `TXT_RANDOM_MAP_DESCRIPTION` before running the generator.
+- Raw MapSeed load slot `0x00597A30` has instructions but no Ghidra Function
+  object. Listing `0x00597B11..0x00597CB2` shows all sixteen integer reads
+  passing the current receiver field as the INI default, then storing the
+  reader return to that field. Description is different: `0x00597ADE..0x00597B0C`
+  passes the localized random-map description default to `0x00528F00`.
+  No new function boundary was created.
+
+Reproduce these reads with `get_assembly_context` at `0x00597A30` and
+`0x0059694A`, 190 context instructions, and decompile `0x00596300`,
+`0x00596C70`, `0x00596E50`. Existing
+[saved-seed research](RANDOM_MAP_SAVED_SEED_SLOTS_GHIDRA_REPORT.md) supplies the
+active caller/vtable chain; its old implementation-gap list is historical.
+
+## Rust change and validation boundary
+
+`load_saved_seed` now receives the current option record instead of constructing
+defaults. The production Load handler supplies its live working options and the
+localized Description fallback. It retains its existing invalidation behavior;
+automatic preview generation is still missing. Failed file reads leave the
+browser and setup intact. A failed worker releases controls
+without marking the old or partial preview as a successful map; only successful
+completion can enable Save and Use Map.
+
+Regression coverage is recorded in the validation/review packet for the candidate.
+The focused loader test exercises a partial seed with all non-default retained
+integer fields, clamping, localized and explicit descriptions, and a vanished
+file. The failure test exercises old/partial result invalidation, disabled
+Save/Accept and a successful retry. This does not demonstrate
+native pixel parity or terrain-generator equivalence. Full browser interaction,
+native file-parser edge cases and every shell route remain unclosed.
+
+Completing automatic Load-to-Generate requires one owner
+for control readback, immediate option-edit derived randomization, the load
+latch and Generate; the native map-type `-1` reads preceding range/vector storage
+and must not be replaced with an invented clamped bucket.
+
+## Shared Ghidra annotations
+
+The independent critics confirmed the numeric/default identity and the
+conditional Load latch behavior from original instructions. The existing
+`0x00596E50` plate now records these loading boundaries; the contradictory
+unconditional Load-preservation paragraph at `0x00596C70` was corrected.
+The `0x00597260` plate also records the raw `-1` argument exception without
+guessing predecessor storage. These updates preserved unrelated text, were saved
+to `gamemd.exe`, and were
+read back exactly. No executable bytes, function boundaries or types changed.
+
+## Rust regression tested (2026-09-12 candidate)
+
+- `cargo test -p vera20k --lib`: 8,686 passed, 0 failed, 121 ignored.
+  This includes
+  `map::rmg::saved_seeds::tests::partial_seed_preserves_current_integers_and_uses_localized_description_default`
+  and
+  `ui::skirmish_shell::state::random_map_setup::tests::failed_generation_cannot_accept_or_save_old_or_partial_results`.
+- `cargo clippy -p vera20k --lib`: exit 0, 1,147 warnings; no warnings were
+  treated as proof of parity or ignored test coverage.
+- `git diff --check`: clean. `python -m tools.system_map check`: 0 errors
+  across 3 files.
+
+Fresh independent read-only review traced the native defaults and localized
+fallback, the sole production loader caller, both worker-failure paths, retained
+candidate invalidation, Save/Accept consumers and preview-cache clearing. These
+checks support the bounded fixes, not completed RMG behavior or rendered parity.
+No new native/Rust frame comparison was performed for this increment.

--- a/src/app/shell_random_map.rs
+++ b/src/app/shell_random_map.rs
@@ -701,7 +701,7 @@ impl App {
                 .random_map_setup_modal
                 .as_mut()
             {
-                modal.finish_generate(None);
+                modal.fail_generate();
             }
             return true;
         }
@@ -987,20 +987,28 @@ impl App {
         match outcome {
             Outcome::Close => state.frontend.skirmish_shell_state.saved_seed_browser = None,
             Outcome::Load(file_name) => {
-                match crate::map::rmg::saved_seeds::load_saved_seed(&dir.join(&file_name)) {
+                let description = Self::csf_label(
+                    state,
+                    RANDOM_MAP_DESCRIPTION_KEY,
+                    RANDOM_MAP_DESCRIPTION_FALLBACK,
+                );
+                let Some(modal) = state
+                    .frontend
+                    .skirmish_shell_state
+                    .random_map_setup_modal
+                    .as_mut()
+                else {
+                    return true;
+                };
+                match crate::map::rmg::saved_seeds::load_saved_seed(
+                    &dir.join(&file_name),
+                    &modal.options,
+                    &description,
+                ) {
                     Ok(options) => {
-                        // Loading replaces the working options and invalidates
-                        // any generated result, exactly as an edit would.
-                        if let Some(modal) = state
-                            .frontend
-                            .skirmish_shell_state
-                            .random_map_setup_modal
-                            .as_mut()
-                        {
-                            modal.options = options;
-                            modal.generated = false;
-                            modal.generated_preview = None;
-                        }
+                        modal.options = options;
+                        modal.generated = false;
+                        modal.generated_preview = None;
                         state.frontend.skirmish_shell_state.saved_seed_browser = None;
                     }
                     Err(err) => log::warn!("saved seed: could not read {file_name}: {err}"),
@@ -1368,7 +1376,7 @@ impl App {
                     .random_map_setup_modal
                     .as_mut()
                 {
-                    modal.finish_generate(None);
+                    modal.fail_generate();
                 }
             }
             // Accept, if it was asked for, is now the job's responsibility.

--- a/src/map/rmg/saved_seeds.rs
+++ b/src/map/rmg/saved_seeds.rs
@@ -122,12 +122,20 @@ pub fn seed_path_for_name(dir: &Path, typed_name: &str) -> Option<PathBuf> {
 
 /// Read a saved seed's options.
 ///
-/// Missing keys keep their defaults, matching how the engine leaves its record
-/// alone for anything the file does not mention. The result is normalised, so a
-/// hand-edited file cannot push the dialog outside its own ranges.
-pub fn load_saved_seed(path: &Path) -> std::io::Result<RmgOptions> {
+/// MapSeedClass load slot 0x00597A30 overlays the current record: missing keys
+/// retain the player's working values. The setup caller at 0x005969B1 then
+/// synchronizes controls through 0x00596E50, which normalizes the record.
+/// See RANDOM_MAP_SAVED_SEED_SLOTS_GHIDRA_REPORT.md sections 3.5 and 3.6.
+pub fn load_saved_seed(
+    path: &Path,
+    current: &RmgOptions,
+    default_description: &str,
+) -> std::io::Result<RmgOptions> {
     let bytes = std::fs::read(path)?;
-    let mut options = RmgOptions::default();
+    let mut options = current.clone();
+    // Unlike the integer keys, Description uses the localized default passed
+    // at 0x00597AFD to INIClass__ReadCommaHexUTF16, not the current description.
+    options.description = default_description.to_owned();
     if let Ok(ini) = crate::rules::ini_parser::IniFile::from_bytes(&bytes) {
         options.apply_sed(&ini);
     }
@@ -148,6 +156,65 @@ pub fn delete_saved_seed(path: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn partial_seed_preserves_current_integers_and_uses_localized_description_default() {
+        let path = std::env::temp_dir().join(format!(
+            "vera20k-partial-seed-{}-{}.sed",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(
+            &path,
+            b"[RandomMap]\nSeed=4660\nWaterAmount=73\nNumPlayers=99\n",
+        )
+        .unwrap();
+        let current = RmgOptions {
+            theater: 1,
+            map_type: 3,
+            resources: 2,
+            ruggedness: 67,
+            time: 3,
+            water_amount: 31,
+            num_players: 6,
+            tiberium: 47,
+            tiberium_layout: 19,
+            vegetation: 29,
+            urban_presence: 13,
+            width: 2,
+            height: 1,
+            accessibility: 89,
+            region_size: 83,
+            seed: 42,
+            description: "Prior map".into(),
+        };
+        let loaded = load_saved_seed(&path, &current, "Localized random map").unwrap();
+        let expected = RmgOptions {
+            seed: 4660,
+            water_amount: 73,
+            num_players: 8,
+            description: "Localized random map".into(),
+            ..current.clone()
+        };
+        assert_eq!(loaded, expected);
+        // Description has its own comma-hex reader/default contract.
+        std::fs::write(&path, b"[RandomMap]\nDescription=53,61,76,65,64,\n").unwrap();
+        assert_eq!(
+            load_saved_seed(&path, &current, "fallback")
+                .unwrap()
+                .description,
+            "Saved"
+        );
+        std::fs::remove_file(&path).unwrap();
+        assert!(load_saved_seed(&path, &current, "fallback").is_err());
+        assert_eq!(
+            current.seed, 42,
+            "loading never mutates the supplied record"
+        );
+    }
 
     #[test]
     fn reserved_names_are_matched_regardless_of_case() {
@@ -230,7 +297,7 @@ mod tests {
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].display_name, "Desert Duel");
 
-        let loaded = load_saved_seed(&path).expect("load");
+        let loaded = load_saved_seed(&path, &RmgOptions::default(), "Random Map").expect("load");
         assert_eq!(loaded.seed, 4242);
         assert_eq!(loaded.num_players, 6);
         assert_eq!(loaded.map_type, 3);

--- a/src/ui/skirmish_shell/state/random_map_setup.rs
+++ b/src/ui/skirmish_shell/state/random_map_setup.rs
@@ -342,6 +342,14 @@ impl RandomMapSetupModalState {
         self.dragging_players_thumb = false;
     }
 
+    /// Release a failed worker without presenting an old/partial map as a
+    /// successful result. Only finish_generate may enable Save and Accept.
+    pub fn fail_generate(&mut self) {
+        self.generating = false;
+        self.generated = false;
+        self.generated_preview = None;
+    }
+
     /// Show the map as it stands part-way through the generate block.
     ///
     /// The original draws its preview repeatedly while generating, so the player
@@ -578,6 +586,32 @@ mod tests {
         state.finish_generate(None);
         assert!(state.is_enabled(RandomMapSetupControl::Ok0x6c5));
         assert!(state.is_enabled(RandomMapSetupControl::Cancel0x5c0));
+    }
+
+    #[test]
+    fn failed_generation_cannot_accept_or_save_old_or_partial_results() {
+        for had_prior_result in [false, true] {
+            let mut state = opened();
+            if had_prior_result {
+                state.finish_generate(Some(one_pixel_preview()));
+            }
+            state.begin_generate();
+            state.show_progress_preview(one_pixel_preview());
+            state.fail_generate();
+            assert!(!state.generating);
+            assert!(!state.generated);
+            assert!(state.generated_preview.is_none());
+            assert!(!state.is_enabled(RandomMapSetupControl::Ok0x6c5));
+            assert!(!state.is_enabled(RandomMapSetupControl::Save0x6c3));
+            assert!(state.is_enabled(RandomMapSetupControl::Generate0x620));
+            assert!(state.is_enabled(RandomMapSetupControl::Cancel0x5c0));
+            assert_eq!(state.accept(), AcceptOutcome::NeedsGenerate);
+            // Retrying and succeeding is the only path back to acceptance.
+            state.begin_generate();
+            state.finish_generate(Some(one_pixel_preview()));
+            assert!(state.is_enabled(RandomMapSetupControl::Ok0x6c5));
+            assert!(state.is_enabled(RandomMapSetupControl::Save0x6c3));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Loading a partial saved random map now retains the working numeric settings for omitted keys and uses the retail localized Description fallback. Generator startup or worker failure now clears result authority, so an old or partial preview cannot enable Save or Use Map.

The change establishes acceptance for the complete shell task and documents the independently checked native evidence. This increment covers saved-seed defaults and failed-generation handling; automatic Load generation, control synchronization, browser availability and visual parity remain open.

Validation: 8,686 library tests passed, 0 failed, 121 ignored; both new regressions passed. `cargo clippy -p vera20k --lib` exited successfully with 1,147 warnings. Diff and documentation-link checks passed; System Map check reported 0 errors. Fresh independent read-only review passed the bounded increment. Confirmed Ghidra comments were corrected, saved and read back against the pinned retail binary.
