### PR TITLE
Add production skirmish capture checkpoint

### DIFF
--- a/docs/research/skirmish-ui/2026-09-12-production-capture.md
+++ b/docs/research/skirmish-ui/2026-09-12-production-capture.md
@@ -1,0 +1,76 @@
+# Production skirmish capture prerequisite
+
+Scope: one ordinary steady dialog `0x102` frame at 800×600, cursor `(400,300)`.
+This supplies diagnostic output for the [all-shell acceptance work](../../plans/2026-09-12-retail-shells-acceptance.md).
+It does not establish retail parity or close any shell family.
+
+The checkpoint uses the existing Main Menu → Single Player → Skirmish action
+handlers only after an ordinary frame is presented. It does not assign routes
+directly, clone shell state, synthesize OS input or render an alternate scene.
+The renderer identifies the branch actually drawn. The session waits for
+completed skirmish slide/title/game-type/map-label reveals, observes a steady
+frame, and captures the next final swapchain frame after the RGB565 presenter.
+Never-started reveals are distinguished from completed reveals.
+
+The session rejects a changed surface/cursor, developer shortcut, fallback,
+active modal/edit/drag/dropdown/generation, missing chrome or selected preview,
+wrong return route, surviving source movie, or changed selection. A separate
+manifest and validator preserve the sealed main-menu contracts. Capture startup
+continues to suppress physical RA2MD.INI options loading; recorded skirmish
+selection reflects the existing production initialization. Asset and profile
+enrollment must precede a native comparison.
+
+An initial hidden run exposed another `about_to_wait` callback after successful
+capture and an exit request. The shell capture pump now exits immediately when
+the session already has an outcome, preventing another surface acquisition and
+a misleading post-success render error. This changes only the diagnostic pump.
+
+## Evidence and validation
+
+Final hidden run: normal route actions at frames 35 and 51; skirmish capture
+at frame 107, `PcOfDune.MAP`, Battle mode, 1,920,000 BGRA8 bytes. Frame SHA-256:
+`fe7d42bfebaca25a608e1be3485a2f2f576beca75867ae4961a73a546c42f8fa`.
+The frame was decoded and visually inspected: complete chrome, roster,
+preview, settings and buttons. This is a Rust output observation, not a native
+comparison. After the pump correction, child PID 29764 exited successfully and
+reproduced the first run's exact pixels. The retained log is cumulative: the
+first run's error remains at 11:15:17 UTC; the final run starts at 11:18:14 UTC
+and records no new error. Palette/Vulkan-layer warnings remain visible in logs.
+
+The existing main-menu steady checkpoint also ran successfully (child PID
+14436), passed its original validator and retained the typed manifest field
+order. Runtime rejection checks returned failure for existing output, wrong
+dimensions, wrong cursor and a developer shortcut; no new rejected bundle was
+created. These checks use the final built executable.
+
+Local reproduction artifacts are retained under the owning worktree's `.local/`:
+capture manifest/pixels/PNG, child stdout/stderr, run command, executable/config
+and input pre/post SHA-256 inventory. The recorded local INI and retail top-level
+MIX/INI/CSF/SHP/FNT/PAL/MAP/MPR/SED/IMG files remained unchanged. This inventory
+does not claim complete input enrollment. Retail bytes are not committed.
+
+The new guard regression exercises each invalid capture boundary, including
+nonfinite cursor position. Reveal regression distinguishes default, completion
+and restart. The artifact tests reject changed/truncated payloads, duplicate JSON
+keys, path escape, incomplete navigation, malformed selection and parity claims.
+The Python certification suite ran 63 tests: 62 passed and one optional
+sealed-evidence test was skipped. The full Rust library suite passed 8,688 tests
+with 121 ignored and no failures. Clippy completed successfully with 1,147
+warnings. Documentation links, the system-map check and diff whitespace checks
+passed. Fresh independent read-only criticism found and rechecked the manifest
+serialization and strict cursor-type corrections; no implementation findings
+remain.
+
+## Native evidence and remaining scope
+
+The diagnostic route invokes existing handlers and adds no gamemd behavior or
+new reverse-engineering conclusion. Independent read-only review confirmed no
+new Ghidra labels/comments are warranted for this prerequisite; existing native
+identities remain with their production owners. Speculative annotations would
+not improve evidence.
+
+The separate skirmish schema explicitly reports `parity_certification: NONE` and
+unenrolled inputs. No native skirmish reference frame was captured. This work
+does not validate physical input, focus, audio, transition timing, any child
+dialog, other resolution, persisted selection parity, launch, or return/reentry.
+Those remain required by the full-scope acceptance document.

--- a/src/app/diagnostics/shell_capture.rs
+++ b/src/app/diagnostics/shell_capture.rs
@@ -22,9 +22,13 @@ use crate::ui::game_screen::GameScreen;
 use crate::ui::main_menu_shell::MainMenuMovieBase;
 use crate::ui::shell::static_reveal::Kind1PaintWindow;
 
+mod skirmish;
+pub(crate) use skirmish::PresentedShell;
+
 pub(crate) const CAPTURE_FLAG: &str = "--shell-capture";
 const CHECKPOINT_MAIN_MENU_0XE2_STEADY: &str = "main-menu-0xe2-steady";
 const CHECKPOINT_MAIN_MENU_0XE2_ENTRY_SEQUENCE: &str = "main-menu-0xe2-entry-sequence";
+const CHECKPOINT_SKIRMISH_0X102_STEADY: &str = "skirmish-0x102-steady";
 const EXPECTED_WIDTH: u32 = 800;
 const EXPECTED_HEIGHT: u32 = 600;
 const EXPECTED_CURSOR_X: u32 = 400;
@@ -51,6 +55,7 @@ pub enum AppLaunchMode {
 pub enum ShellCaptureCheckpoint {
     MainMenu0xE2Steady,
     MainMenu0xE2EntrySequence,
+    Skirmish0x102Steady,
 }
 
 impl ShellCaptureCheckpoint {
@@ -58,6 +63,7 @@ impl ShellCaptureCheckpoint {
         match value {
             CHECKPOINT_MAIN_MENU_0XE2_STEADY => Ok(Self::MainMenu0xE2Steady),
             CHECKPOINT_MAIN_MENU_0XE2_ENTRY_SEQUENCE => Ok(Self::MainMenu0xE2EntrySequence),
+            CHECKPOINT_SKIRMISH_0X102_STEADY => Ok(Self::Skirmish0x102Steady),
             _ => bail!("unsupported shell-capture checkpoint {value:?}"),
         }
     }
@@ -66,6 +72,7 @@ impl ShellCaptureCheckpoint {
         match self {
             Self::MainMenu0xE2Steady => CHECKPOINT_MAIN_MENU_0XE2_STEADY,
             Self::MainMenu0xE2EntrySequence => CHECKPOINT_MAIN_MENU_0XE2_ENTRY_SEQUENCE,
+            Self::Skirmish0x102Steady => CHECKPOINT_SKIRMISH_0X102_STEADY,
         }
     }
 }
@@ -298,7 +305,8 @@ impl MainMenuCaptureSnapshot {
             main_menu_screen: state.frontend.screen == GameScreen::MainMenu,
             shell_failed: state.frontend.main_menu_shell_failed,
             single_player_active: state.frontend.shell_route.single_player(),
-            skirmish_active: state.frontend.shell_route.skirmish() || state.frontend.dev_skirmish_shell_enabled,
+            skirmish_active: state.frontend.shell_route.skirmish()
+                || state.frontend.dev_skirmish_shell_enabled,
             // The legacy skirmish-setup flag was write-dead (never set after
             // startup); the capture snapshot keeps the field as literal false.
             legacy_skirmish_setup_active: false,
@@ -308,7 +316,8 @@ impl MainMenuCaptureSnapshot {
             active_slide_is_main_menu: state.frontend.shell_slide_active_shell
                 == Some(ShellSlideKind::MainMenu),
             title_terminal_persistent: state
-                .frontend.main_menu_shell_state
+                .frontend
+                .main_menu_shell_state
                 .title_reveal
                 .is_terminal_persistent(),
             movie_loaded: state.frontend.main_menu_movie.is_some(),
@@ -455,6 +464,7 @@ pub(crate) struct ShellCaptureSession {
     frames_seen: u32,
     readback_started: bool,
     entry_sequence: Option<EntrySequenceState>,
+    skirmish: Option<skirmish::SkirmishCapture>,
     outcome: Option<std::result::Result<(), String>>,
 }
 
@@ -463,12 +473,15 @@ impl ShellCaptureSession {
         let entry_sequence = (request.checkpoint
             == ShellCaptureCheckpoint::MainMenu0xE2EntrySequence)
             .then(EntrySequenceState::default);
+        let skirmish = (request.checkpoint == ShellCaptureCheckpoint::Skirmish0x102Steady)
+            .then(skirmish::SkirmishCapture::default);
         Self {
             request,
             started_at: None,
             frames_seen: 0,
             readback_started: false,
             entry_sequence,
+            skirmish,
             outcome: None,
         }
     }
@@ -495,6 +508,32 @@ impl ShellCaptureSession {
         self.started_at = Some(Instant::now());
     }
 
+    fn timeout(&self) -> Duration {
+        if self.skirmish.is_some() {
+            Duration::from_secs(60)
+        } else {
+            CAPTURE_TIMEOUT
+        }
+    }
+
+    fn steady_ready(&self, state: &AppState) -> Result<bool> {
+        match &self.skirmish {
+            Some(capture) => capture.ready(state),
+            None => steady_main_menu_capture_ready(MainMenuCaptureSnapshot::from_state(state)),
+        }
+    }
+
+    pub(crate) fn after_present(
+        &mut self,
+        state: &mut AppState,
+        rendered: PresentedShell,
+    ) -> Result<()> {
+        if let Some(capture) = &mut self.skirmish {
+            capture.after_present(state, rendered, self.frames_seen)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn should_capture_current_frame(&mut self, state: &AppState) -> Result<bool> {
         ensure!(
             self.outcome.is_none(),
@@ -509,9 +548,9 @@ impl ShellCaptureSession {
             "shell capture exceeded {MAX_CAPTURE_FRAMES} frames"
         );
         ensure!(
-            started_at.elapsed() <= CAPTURE_TIMEOUT,
+            started_at.elapsed() <= self.timeout(),
             "shell capture timed out after {} seconds",
-            CAPTURE_TIMEOUT.as_secs()
+            self.timeout().as_secs()
         );
 
         if self.is_entry_sequence() {
@@ -521,7 +560,7 @@ impl ShellCaptureSession {
             !self.readback_started,
             "shell capture attempted more than one readback"
         );
-        let ready = steady_main_menu_capture_ready(MainMenuCaptureSnapshot::from_state(state))?;
+        let ready = self.steady_ready(state)?;
         if ready {
             self.readback_started = true;
         }
@@ -588,7 +627,11 @@ impl ShellCaptureSession {
         );
         ensure!(
             matches!(
-                state.frontend.main_menu_shell_state.title_reveal.paint_window(),
+                state
+                    .frontend
+                    .main_menu_shell_state
+                    .title_reveal
+                    .paint_window(),
                 Kind1PaintWindow::Hidden
             ),
             "entry sequence title became visible"
@@ -623,7 +666,8 @@ impl ShellCaptureSession {
         let started_at = self
             .started_at
             .context("shell capture was not initialized")?;
-        let remaining = CAPTURE_TIMEOUT
+        let remaining = self
+            .timeout()
             .checked_sub(started_at.elapsed())
             .context("shell capture timeout expired before GPU readback")?;
         ensure!(
@@ -666,7 +710,7 @@ impl ShellCaptureSession {
             pixels.len()
         );
         ensure!(
-            steady_main_menu_capture_ready(MainMenuCaptureSnapshot::from_state(state))?,
+            self.steady_ready(state)?,
             "capture state changed before bundle write"
         );
 
@@ -679,9 +723,20 @@ impl ShellCaptureSession {
         let frame_path = self.request.output_dir().join(FRAME_FILE_NAME);
         write_new_file(&frame_path, pixels)?;
 
-        let manifest = capture_manifest(&self.request, surface_format, pixels.len() as u64);
-        let mut manifest_bytes =
-            serde_json::to_vec_pretty(&manifest).context("serialize shell-capture manifest")?;
+        let mut manifest_bytes = match &self.skirmish {
+            Some(capture) => serde_json::to_vec_pretty(&capture.manifest(
+                &self.request,
+                surface_format,
+                pixels,
+                self.frames_seen,
+            )),
+            None => serde_json::to_vec_pretty(&capture_manifest(
+                &self.request,
+                surface_format,
+                pixels.len() as u64,
+            )),
+        }
+        .context("serialize shell-capture manifest")?;
         manifest_bytes.push(b'\n');
         let manifest_path = self.request.output_dir().join(MANIFEST_FILE_NAME);
         write_new_file(&manifest_path, &manifest_bytes)?;
@@ -747,9 +802,9 @@ impl ShellCaptureSession {
                 !remaining.is_zero(),
                 "entry sequence timeout expired during deferred readback"
             );
-            let pixels = item
-                .readback
-                .finish(&state.renderer.gpu.device, item.submission, remaining)?;
+            let pixels =
+                item.readback
+                    .finish(&state.renderer.gpu.device, item.submission, remaining)?;
             ensure!(
                 pixels.len() as u64 == FRAME_BYTE_LENGTH,
                 "entry-sequence tick {expected_tick} length mismatch: expected \
@@ -777,7 +832,8 @@ impl ShellCaptureSession {
                 .join(ENTRY_SEQUENCE_FRAMES_FILE_NAME),
             &payload,
         )?;
-        let manifest = entry_sequence_manifest(&self.request, state.renderer.gpu.config.format, generation);
+        let manifest =
+            entry_sequence_manifest(&self.request, state.renderer.gpu.config.format, generation);
         let mut manifest_bytes =
             serde_json::to_vec_pretty(&manifest).context("serialize entry-sequence manifest")?;
         manifest_bytes.push(b'\n');
@@ -1065,6 +1121,24 @@ mod tests {
             request.checkpoint().as_str(),
             "main-menu-0xe2-entry-sequence"
         );
+    }
+
+    #[test]
+    fn skirmish_capture_uses_distinct_checkpoint_and_route_budget() {
+        let output = new_output_path("skirmish");
+        let mut values = valid_args(&output);
+        values[1] = OsString::from(CHECKPOINT_SKIRMISH_0X102_STEADY);
+        let AppLaunchMode::ShellCapture(request) = parse_launch_args(values).expect("parse") else {
+            panic!("expected capture");
+        };
+        let session = ShellCaptureSession::new(request);
+        assert_eq!(
+            session.request().checkpoint(),
+            ShellCaptureCheckpoint::Skirmish0x102Steady
+        );
+        assert_eq!(session.timeout(), Duration::from_secs(60));
+        assert!(!session.is_entry_sequence());
+        assert!(session.skirmish.is_some());
     }
 
     #[test]

--- a/src/app/diagnostics/shell_capture/skirmish.rs
+++ b/src/app/diagnostics/shell_capture/skirmish.rs
@@ -1,0 +1,319 @@
+//! Production-only Skirmish capture route. No shell state or renderer is cloned.
+
+use super::*;
+use crate::app::App;
+use serde_json::{Value, json};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PresentedShell {
+    Other,
+    MainMenu,
+    SinglePlayer,
+    Skirmish,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    #[default]
+    MainMenu,
+    SinglePlayer,
+    Skirmish,
+}
+
+#[derive(Default)]
+pub(super) struct SkirmishCapture {
+    phase: Phase,
+    route: Vec<Value>,
+    selected_scene: Option<Value>,
+    last_presented: Option<PresentedShell>,
+}
+
+#[derive(Clone, Copy)]
+struct CaptureGuard {
+    main_menu_screen: bool,
+    surface: (u32, u32),
+    failed: bool,
+    developer_shortcut: bool,
+    software_cursor: bool,
+    cursor: (f32, f32),
+    interaction_active: bool,
+}
+
+impl CaptureGuard {
+    fn validate(self) -> Result<()> {
+        ensure!(self.main_menu_screen, "skirmish capture left the shell");
+        ensure!(
+            self.surface == (EXPECTED_WIDTH, EXPECTED_HEIGHT),
+            "skirmish capture surface changed"
+        );
+        ensure!(
+            !self.failed && !self.developer_shortcut,
+            "skirmish capture encountered fallback or a developer shortcut"
+        );
+        ensure!(self.software_cursor, "software cursor unavailable");
+        ensure!(
+            self.cursor == (EXPECTED_CURSOR_X as f32, EXPECTED_CURSOR_Y as f32),
+            "capture cursor moved"
+        );
+        ensure!(
+            !self.interaction_active,
+            "skirmish capture encountered modal, editing or interaction state"
+        );
+        Ok(())
+    }
+}
+
+fn guard(state: &AppState) -> Result<()> {
+    let shell = &state.frontend.skirmish_shell_state;
+    CaptureGuard {
+        main_menu_screen: state.frontend.screen == GameScreen::MainMenu,
+        surface: (state.render_width(), state.render_height()),
+        failed: state.frontend.main_menu_shell_failed,
+        developer_shortcut: state.frontend.dev_skirmish_shell_enabled,
+        software_cursor: state.use_software_cursor(),
+        cursor: (
+            state.match_state.input.cursor_x,
+            state.match_state.input.cursor_y,
+        ),
+        interaction_active: state.main_menu_dialog_open()
+            || state.frontend.quit_cascade.is_some()
+            || state.match_state.match_presentation.show_save_load_panel
+            || shell.choose_map_modal.is_some()
+            || shell.validation_modal.is_some()
+            || shell.random_map_setup_modal.is_some()
+            || shell.saved_seed_browser.is_some()
+            || state.frontend.random_map_generation.is_some()
+            || shell.open_combo_dropdown.is_some()
+            || shell.trackbar_drag.is_some()
+            || shell.dropdown_scroll_drag.is_some()
+            || shell.dropdown_scroll_press.is_some()
+            || shell.pressed_owner_draw_button.is_some()
+            || shell.player_name_edit.focused,
+    }
+    .validate()
+}
+
+fn selected_scene(state: &AppState) -> Result<Value> {
+    let shell = &state.frontend.skirmish_shell_state;
+    let map = state
+        .frontend
+        .scenario_catalog
+        .shell_maps()
+        .get(shell.selected_map_idx)
+        .context("skirmish capture has no selected map")?;
+    let preview = state
+        .frontend
+        .skirmish_preview_texture
+        .as_ref()
+        .context("selected map preview is unavailable for this capture checkpoint")?;
+    ensure!(
+        preview.selected_map_idx == shell.selected_map_idx
+            && preview.setup_preview_generation.is_none(),
+        "capture preview belongs to another selection"
+    );
+    Ok(json!({
+        "map_file": map.file_name, "map_label": map.display_name,
+        "map_capacity": map.player_capacity, "mode_id": shell.selected_mode_id,
+        "preview": { "width": preview.width, "height": preview.height },
+        "parsed_map_sha256": crate::util::sha256::sha256_hex(format!("{map:?}").as_bytes()),
+        "parsed_map_hash_encoding": "Rust Debug representation; diagnostic identity only",
+        "player": {
+            "name": shell.player_name_edit.text, "country": format!("{:?}", shell.player_country),
+            "country_random": shell.player_country_random, "color": shell.player_color_index,
+            "color_claimed": shell.player_color_claimed,
+            "start": format!("{:?}", shell.player_start_position), "team": shell.player_team
+        },
+        "opponents": shell.opponents.iter().enumerate().map(|(index, row)| json!({
+            "visible": crate::ui::skirmish_shell::player_row_visible(shell, state.frontend.scenario_catalog.shell_maps(), index + 1),
+            "enabled": row.enabled, "type": format!("{:?}", row.row_type),
+            "country": format!("{:?}", row.country), "country_random": row.country_random,
+            "color": row.color_index, "color_claimed": row.color_claimed,
+            "start": format!("{:?}", row.start_position), "team": row.team
+        })).collect::<Vec<_>>(),
+        "options": {
+            "credits": shell.starting_credits, "speed": shell.game_speed, "units": shell.unit_count,
+            "short_game": shell.short_game, "super_weapons": shell.super_weapons,
+            "build_off_ally": shell.build_off_ally, "crates": shell.crates,
+            "mcv_redeploy": shell.mcv_redeploy, "zoom": shell.zoom_enabled
+        }
+    }))
+}
+
+impl SkirmishCapture {
+    /// Called only after an ordinary production frame has been presented. Route
+    /// actions run here, never between frame acquisition and shell dispatch.
+    pub(super) fn after_present(
+        &mut self,
+        state: &mut AppState,
+        rendered: PresentedShell,
+        frame: u32,
+    ) -> Result<()> {
+        guard(state)?;
+        self.last_presented = Some(rendered);
+        match (self.phase, rendered) {
+            (Phase::MainMenu, PresentedShell::MainMenu) => {
+                if steady_main_menu_capture_ready(MainMenuCaptureSnapshot::from_state(state))? {
+                    self.route
+                        .push(json!({"dialog": 0xe2, "frame": frame, "action": "SinglePlayer"}));
+                    App::handle_main_menu_shell_action(
+                        state,
+                        crate::ui::main_menu_shell::MainMenuShellAction::SinglePlayer,
+                    );
+                    self.phase = Phase::SinglePlayer;
+                }
+            }
+            (Phase::SinglePlayer, PresentedShell::SinglePlayer) => {
+                ensure!(
+                    state.frontend.shell_route.single_player(),
+                    "Single Player route changed"
+                );
+                ensure!(
+                    state
+                        .frontend
+                        .main_menu_movie_identity
+                        .is_some_and(
+                            |identity| identity.owner() == Ra2tsDialogOwner::SinglePlayer0x100
+                        ),
+                    "Single Player movie identity unavailable"
+                );
+                if state.frontend.shell_first_paint_slide.is_none()
+                    && state.frontend.shell_slide_active_shell == Some(ShellSlideKind::SinglePlayer)
+                {
+                    self.route
+                        .push(json!({"dialog": 0x100, "frame": frame, "action": "Skirmish"}));
+                    App::handle_single_player_shell_action(
+                        state,
+                        crate::ui::single_player_shell::SinglePlayerShellAction::Skirmish,
+                    );
+                    self.phase = Phase::Skirmish;
+                }
+            }
+            (Phase::Skirmish, PresentedShell::Skirmish) => {
+                if self.settled(state)? && self.selected_scene.is_none() {
+                    self.selected_scene = Some(selected_scene(state)?);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn settled(&self, state: &AppState) -> Result<bool> {
+        guard(state)?;
+        ensure!(
+            state
+                .frontend
+                .shell_route
+                .skirmish_returns_to_single_player(),
+            "skirmish capture bypassed Single Player"
+        );
+        ensure!(
+            state.frontend.skirmish_shell_chrome.is_some(),
+            "skirmish chrome unavailable"
+        );
+        ensure!(
+            state.frontend.main_menu_movie.is_none(),
+            "prior shell movie survived skirmish entry"
+        );
+        let shell = &state.frontend.skirmish_shell_state;
+        Ok(state.frontend.shell_first_paint_slide.is_none()
+            && state.frontend.shell_slide_active_shell == Some(ShellSlideKind::Skirmish)
+            && shell.title_reveal.has_completed()
+            && shell.game_type_reveal.has_completed()
+            && shell.map_label_reveal.has_completed())
+    }
+
+    pub(super) fn ready(&self, state: &AppState) -> Result<bool> {
+        guard(state)?;
+        if self.phase != Phase::Skirmish
+            || self.last_presented != Some(PresentedShell::Skirmish)
+            || self.selected_scene.is_none()
+        {
+            return Ok(false);
+        }
+        if !self.settled(state)? {
+            return Ok(false);
+        }
+        ensure!(
+            self.selected_scene.as_ref() == Some(&selected_scene(state)?),
+            "selected skirmish state changed during capture"
+        );
+        Ok(true)
+    }
+
+    pub(super) fn manifest(
+        &self,
+        request: &ShellCaptureRequest,
+        format: wgpu::TextureFormat,
+        pixels: &[u8],
+        frame: u32,
+    ) -> Value {
+        json!({
+            "schema_version": "vera20k.skirmish-shell-capture.v1", "checkpoint": request.checkpoint.as_str(),
+            "parity_certification": "NONE", "presenter_domain": "final-swapchain-after-rgb565",
+            "surface": {"width": request.width, "height": request.height, "format": format!("{format:?}"),
+                "pixel_layout": "BGRA8", "row_order": "top-left", "row_stride": request.width * 4},
+            "cursor": {"x": request.cursor_x, "y": request.cursor_y, "policy": "software-composited"},
+            "route": self.route, "dialog_resource_id": 0x102, "capture_frame": frame,
+            "selection": self.selected_scene, "reveals_completed": true, "ordinary_skirmish_frame": true,
+            "input_enrollment": "UNENROLLED; asset/profile bytes require enrollment before native comparison",
+            "frame": {"path": FRAME_FILE_NAME, "byte_length": pixels.len(),
+                "sha256": crate::util::sha256::sha256_hex(pixels)}
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_guard_rejects_each_invalid_boundary() {
+        let valid = CaptureGuard {
+            main_menu_screen: true,
+            surface: (800, 600),
+            failed: false,
+            developer_shortcut: false,
+            software_cursor: true,
+            cursor: (400.0, 300.0),
+            interaction_active: false,
+        };
+        assert!(valid.validate().is_ok());
+        for invalid in [
+            CaptureGuard {
+                main_menu_screen: false,
+                ..valid
+            },
+            CaptureGuard {
+                surface: (640, 480),
+                ..valid
+            },
+            CaptureGuard {
+                failed: true,
+                ..valid
+            },
+            CaptureGuard {
+                developer_shortcut: true,
+                ..valid
+            },
+            CaptureGuard {
+                software_cursor: false,
+                ..valid
+            },
+            CaptureGuard {
+                cursor: (401.0, 300.0),
+                ..valid
+            },
+            CaptureGuard {
+                cursor: (400.0, f32::NAN),
+                ..valid
+            },
+            CaptureGuard {
+                interaction_active: true,
+                ..valid
+            },
+        ] {
+            assert!(invalid.validate().is_err());
+        }
+    }
+}

--- a/src/app/frame.rs
+++ b/src/app/frame.rs
@@ -196,6 +196,8 @@ impl App {
                 });
         let mut pending_main_menu_entry_token = None;
         let mut pending_main_menu_title_receipt = None;
+        use crate::app::diagnostics::shell_capture::PresentedShell;
+        let mut presented_shell = PresentedShell::Other;
 
         crate::app::frontend::shell_transition::activate_shell_first_paint_after_acquire(state);
         // Advance the Skirmish right-panel static text reveals (started at the
@@ -224,6 +226,9 @@ impl App {
                         &mut encoder,
                         &output.texture,
                     )?;
+                    if state.frontend.skirmish_shell_chrome.is_some() {
+                        presented_shell = PresentedShell::Skirmish;
+                    }
                 } else if Self::single_player_shell_active(state) {
                     match crate::app::frontend::single_player_shell_render::render_single_player_shell(
                         state,
@@ -231,6 +236,7 @@ impl App {
                         &output.texture,
                     )? {
                         crate::app::frontend::single_player_shell_render::SinglePlayerShellRenderResult::Rendered => {
+                            presented_shell = PresentedShell::SinglePlayer;
                             state.renderer.egui.begin_frame(&state.platform.window);
                             if state.match_state.match_presentation.show_save_load_panel {
                                 Self::handle_save_load_panel(state);
@@ -266,6 +272,7 @@ impl App {
                             title_receipt,
                         } => {
                             pending_main_menu_title_receipt = title_receipt;
+                            presented_shell = PresentedShell::MainMenu;
                             state.renderer.egui.begin_frame(&state.platform.window);
                             // The SHP shell renders the quit-confirm as an SHP
                             // overlay (and OK exits via its hit-test), so the egui
@@ -585,6 +592,9 @@ impl App {
                     .record_presented(receipt),
                 "main-menu title receipt was stale at present commit"
             );
+        }
+        if let Some(session) = shell_capture.as_deref_mut() {
+            session.after_present(state, presented_shell)?;
         }
         if let Some(pending_capture) = pending_capture {
             let pixels = pending_capture.finish(

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -774,6 +774,12 @@ impl ApplicationHandler for App {
         } else if let (Some(state), Some(session)) =
             (self.state.as_mut(), self.shell_capture.as_mut())
         {
+            // Windows may deliver another wait callback after exit was requested.
+            // The completed one-shot bundle must not enter rendering again.
+            if session.is_finished() {
+                event_loop.exit();
+                return;
+            }
             if let Err(err) = Self::render_frame(state, event_loop, Some(&mut *session), None) {
                 log::error!("Shell capture render: {err:#}");
                 session.fail(format!("shell capture render failed: {err:#}"));

--- a/src/app/shell_main_menu.rs
+++ b/src/app/shell_main_menu.rs
@@ -751,7 +751,7 @@ impl App {
 
     pub(super) fn handle_main_menu_shell_mouse_up(
         state: &mut AppState,
-        event_loop: &ActiveEventLoop,
+        _event_loop: &ActiveEventLoop,
     ) {
         let layout = crate::ui::main_menu_shell::compute_layout(
             state.renderer.gpu.config.width,
@@ -770,7 +770,7 @@ impl App {
             .and_then(crate::ui::main_menu_shell::MainMenuControlId::from_resource_id)
             .map(crate::ui::main_menu_shell::action_for_control)
         {
-            Self::handle_main_menu_shell_action(state, action, event_loop);
+            Self::handle_main_menu_shell_action(state, action);
         }
     }
 
@@ -958,7 +958,7 @@ impl App {
         );
     }
 
-    fn handle_single_player_shell_action(
+    pub(super) fn handle_single_player_shell_action(
         state: &mut AppState,
         action: crate::ui::single_player_shell::SinglePlayerShellAction,
     ) {
@@ -992,14 +992,12 @@ impl App {
         }
     }
 
-    fn handle_main_menu_shell_action(
+    pub(super) fn handle_main_menu_shell_action(
         state: &mut AppState,
         action: crate::ui::main_menu_shell::MainMenuShellAction,
-        event_loop: &ActiveEventLoop,
     ) {
         use crate::ui::main_menu_shell::MainMenuShellAction;
 
-        let _ = event_loop;
         match action {
             MainMenuShellAction::None => {}
             // The original pops a confirm message box here; it does NOT quit on

--- a/src/ui/skirmish_shell/static_reveal.rs
+++ b/src/ui/skirmish_shell/static_reveal.rs
@@ -38,6 +38,13 @@ impl Default for StaticReveal {
 }
 
 impl StaticReveal {
+    /// Unlike the never-started default, a completed run has reached its target.
+    pub(crate) fn has_completed(&self) -> bool {
+        self.running
+            .as_ref()
+            .is_some_and(|run| run.count >= run.target)
+    }
+
     /// Begin (or restart) the reveal for `text` at the given instant.
     /// target = char count + 1 + range (native wcslen(text)+1+range).
     pub fn start(&mut self, text: &str, now: Instant) {
@@ -92,6 +99,7 @@ mod tests {
     fn default_renders_full_text() {
         // Inactive default => no reveal window => renderer draws full string.
         assert_eq!(StaticReveal::default().window(), None);
+        assert!(!StaticReveal::default().has_completed());
     }
 
     #[test]
@@ -107,6 +115,7 @@ mod tests {
         let t0 = Instant::now();
         let mut r = StaticReveal::default();
         r.start("AB", t0); // target = 2+1+8 = 11
+        assert!(!r.has_completed());
         r.advance(t0 + Duration::from_millis(29));
         assert_eq!(r.window().unwrap().count, 1); // not yet
         r.advance(t0 + Duration::from_millis(30));
@@ -121,6 +130,9 @@ mod tests {
             r.advance(t);
         }
         assert_eq!(r.window(), None);
+        assert!(r.has_completed());
+        r.start("new", t);
+        assert!(!r.has_completed());
     }
 
     #[test]

--- a/tools/shell_certification/README.md
+++ b/tools/shell_certification/README.md
@@ -133,3 +133,36 @@ Focused tests:
 ```powershell
 python -m unittest discover -s tools/shell_certification/tests -p 'test_*.py' -v
 ```
+
+## Diagnostic skirmish capture
+
+`skirmish-0x102-steady` is a separate, unenrolled diagnostic checkpoint. It
+follows ordinary Main Menu → Single Player → Skirmish action handlers, waits
+for the slide and three text reveals, observes a steady frame, then records the
+next final swapchain frame. It does not synthesize desktop input. The existing
+main-menu guard, schemas and comparison commands do not accept this checkpoint.
+
+Run from the intended resource directory containing `config.toml`, using an
+absolute executable path and a new absolute output directory:
+
+```powershell
+& C:\path\to\vera20k.exe --shell-capture skirmish-0x102-steady `
+  --width 800 --height 600 --cursor-x 400 --cursor-y 300 `
+  --output C:\path\to\new-skirmish-capture
+python -m tools.shell_certification.skirmish C:\path\to\new-skirmish-capture
+```
+
+The hidden process has a 60-second capture budget after initialization. As with
+other capture modes, startup options use deterministic defaults rather than
+loading the physical RA2MD.INI options profile; skirmish selections still follow
+their production initialization. Record executable, config, asset and selection
+identity for any comparison. The built-in command records selection state but
+does not itself enroll or hash all external inputs.
+
+The validator checks the two-file inventory, route ordering, selection shape,
+dimensions and frame digest. Exit 0 means a valid diagnostic bundle; exit 2
+means invalid input. Every result explicitly says `parity_certification: NONE`.
+The parsed-map digest hashes a Rust Debug representation solely to detect a
+selection change within this capture. It is not a stable asset fingerprint.
+Native input enrollment, reference capture and pixel comparison remain separate
+work. See the [bounded capture evidence](../../docs/research/skirmish-ui/2026-09-12-production-capture.md).

--- a/tools/shell_certification/skirmish.py
+++ b/tools/shell_certification/skirmish.py
@@ -1,0 +1,131 @@
+"""Validate a diagnostic skirmish capture; this never certifies retail parity.
+
+Run ``python -m tools.shell_certification.skirmish CAPTURE_DIRECTORY``.
+Native comparison requires separately enrolled asset and profile inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .core import (
+    ALLOWED_SURFACE_FORMATS, ValidationError, _parse_json_bytes,
+    _read_regular_bytes, _require_array, _require_exact_keys, _require_int,
+    _require_object, _require_string, _require_value, sha256_bytes,
+)
+
+SCHEMA = "vera20k.skirmish-shell-capture.v1"
+CHECKPOINT = "skirmish-0x102-steady"
+FRAME_BYTES = 800 * 600 * 4
+
+
+def _typed_fields(value: object, fields: dict[str, type], label: str) -> None:
+    obj = _require_object(value, label)
+    _require_exact_keys(obj, fields, label)
+    for key, kind in fields.items():
+        if type(obj[key]) is not kind:
+            raise ValidationError(f"{label}.{key} must be {kind.__name__}")
+
+
+def validate_bundle(directory: Path) -> dict:
+    directory = directory.absolute()
+    if directory.is_symlink() or getattr(directory, "is_junction", lambda: False)():
+        raise ValidationError("capture directory must not be a link or junction")
+    if not directory.is_dir() or {p.name for p in directory.iterdir()} != {"capture.json", "frame.bgra"}:
+        raise ValidationError("capture inventory must be exactly capture.json and frame.bgra")
+    raw = _read_regular_bytes(directory / "capture.json", "skirmish manifest", maximum_length=1024 * 1024)
+    manifest = _require_object(_parse_json_bytes(raw, "skirmish manifest"), "manifest")
+    _require_exact_keys(manifest, (
+        "schema_version", "checkpoint", "parity_certification", "presenter_domain",
+        "surface", "cursor", "route", "dialog_resource_id", "capture_frame",
+        "selection", "reveals_completed", "ordinary_skirmish_frame", "input_enrollment", "frame",
+    ), "manifest")
+    for key, expected in {
+        "schema_version": SCHEMA, "checkpoint": CHECKPOINT,
+        "parity_certification": "NONE", "presenter_domain": "final-swapchain-after-rgb565",
+        "dialog_resource_id": 0x102, "reveals_completed": True, "ordinary_skirmish_frame": True,
+        "input_enrollment": "UNENROLLED; asset/profile bytes require enrollment before native comparison",
+    }.items():
+        _require_value(manifest[key], expected, key)
+    surface = _require_object(manifest["surface"], "surface")
+    _require_exact_keys(surface, ("width", "height", "format", "pixel_layout", "row_order", "row_stride"), "surface")
+    for key, expected in {"width": 800, "height": 600, "pixel_layout": "BGRA8", "row_order": "top-left", "row_stride": 3200}.items():
+        _require_value(surface[key], expected, f"surface.{key}")
+    if _require_string(surface["format"], "surface.format") not in ALLOWED_SURFACE_FORMATS:
+        raise ValidationError("unsupported surface format")
+    cursor = _require_object(manifest["cursor"], "cursor")
+    _require_exact_keys(cursor, ("x", "y", "policy"), "cursor")
+    for key, expected in {"x": 400, "y": 300, "policy": "software-composited"}.items():
+        _require_value(cursor[key], expected, f"cursor.{key}")
+    route = _require_array(manifest["route"], "route")
+    if len(route) != 2:
+        raise ValidationError("route requires two ordinary navigation actions")
+    previous = 0
+    for index, (dialog, action) in enumerate(((0xE2, "SinglePlayer"), (0x100, "Skirmish"))):
+        step = _require_object(route[index], f"route[{index}]")
+        _require_exact_keys(step, ("dialog", "frame", "action"), "route step")
+        _require_value(step["dialog"], dialog, "route dialog")
+        _require_value(step["action"], action, "route action")
+        frame = _require_int(step["frame"], "route frame")
+        if frame <= previous:
+            raise ValidationError("route frames must increase from a positive first frame")
+        previous = frame
+    if _require_int(manifest["capture_frame"], "capture_frame") <= previous:
+        raise ValidationError("capture frame must follow navigation")
+    selection = _require_object(manifest["selection"], "selection")
+    _require_exact_keys(selection, (
+        "map_file", "map_label", "map_capacity", "mode_id", "preview", "parsed_map_sha256",
+        "parsed_map_hash_encoding", "player", "opponents", "options",
+    ), "selection")
+    for key in ("map_file", "map_label", "parsed_map_hash_encoding"):
+        _require_string(selection[key], f"selection.{key}")
+    _require_value(selection["parsed_map_hash_encoding"],
+                   "Rust Debug representation; diagnostic identity only", "parsed_map_hash_encoding")
+    for key in ("map_capacity", "mode_id"):
+        _require_int(selection[key], f"selection.{key}")
+    row_fields = {"country": str, "country_random": bool, "color": int,
+                  "color_claimed": bool, "start": str, "team": int}
+    _typed_fields(selection["player"], {"name": str, **row_fields}, "player")
+    _typed_fields(selection["options"], {
+        "credits": int, "speed": int, "units": int, "short_game": bool,
+        "super_weapons": bool, "build_off_ally": bool, "crates": bool,
+        "mcv_redeploy": bool, "zoom": bool,
+    }, "options")
+    for opponent in _require_array(selection["opponents"], "opponents"):
+        _typed_fields(opponent, {"visible": bool, "enabled": bool, "type": str, **row_fields}, "opponent")
+    preview = _require_object(selection["preview"], "preview")
+    _require_exact_keys(preview, ("width", "height"), "preview")
+    for dimension in ("width", "height"):
+        if _require_int(preview[dimension], f"preview.{dimension}") <= 0:
+            raise ValidationError("preview dimensions must be positive")
+    identity = _require_string(selection["parsed_map_sha256"], "parsed_map_sha256")
+    if len(identity) != 64 or any(c not in "0123456789abcdef" for c in identity):
+        raise ValidationError("parsed map diagnostic identity must be lowercase SHA256")
+    frame = _require_object(manifest["frame"], "frame")
+    _require_exact_keys(frame, ("path", "byte_length", "sha256"), "frame")
+    _require_value(frame["path"], "frame.bgra", "frame.path")
+    _require_value(frame["byte_length"], FRAME_BYTES, "frame.byte_length")
+    pixels = _read_regular_bytes(directory / "frame.bgra", "frame", maximum_length=FRAME_BYTES)
+    if len(pixels) != FRAME_BYTES:
+        raise ValidationError("frame byte length mismatch")
+    digest = sha256_bytes(pixels)
+    _require_value(frame["sha256"], digest, "frame.sha256")
+    return {"checkpoint": CHECKPOINT, "capture_valid": True, "parity_certification": "NONE",
+            "frame_sha256": digest, "capture_directory": str(directory)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("capture", type=Path)
+    args = parser.parse_args()
+    try:
+        print(json.dumps(validate_bundle(args.capture), sort_keys=True))
+        return 0
+    except (ValidationError, OSError) as exc:
+        parser.exit(2, f"invalid skirmish capture: {exc}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/shell_certification/tests/test_skirmish.py
+++ b/tools/shell_certification/tests/test_skirmish.py
@@ -1,0 +1,123 @@
+"""Integrity/claim boundaries for diagnostic skirmish captures."""
+
+import copy
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.shell_certification.core import ValidationError
+from tools.shell_certification.skirmish import CHECKPOINT, FRAME_BYTES, SCHEMA, validate_bundle
+
+
+def fixture():
+    return {
+        "schema_version": SCHEMA, "checkpoint": CHECKPOINT, "parity_certification": "NONE",
+        "presenter_domain": "final-swapchain-after-rgb565",
+        "surface": {"width": 800, "height": 600, "format": "Bgra8UnormSrgb",
+                    "pixel_layout": "BGRA8", "row_order": "top-left", "row_stride": 3200},
+        "cursor": {"x": 400, "y": 300, "policy": "software-composited"},
+        "route": [{"dialog": 0xE2, "frame": 20, "action": "SinglePlayer"},
+                  {"dialog": 0x100, "frame": 40, "action": "Skirmish"}],
+        "dialog_resource_id": 0x102, "capture_frame": 60,
+        "reveals_completed": True, "ordinary_skirmish_frame": True,
+        "input_enrollment": "UNENROLLED; asset/profile bytes require enrollment before native comparison",
+        "selection": {
+            "map_file": "test.map", "map_label": "Test", "map_capacity": 2, "mode_id": 1,
+            "preview": {"width": 2, "height": 2}, "parsed_map_sha256": "a" * 64,
+            "parsed_map_hash_encoding": "Rust Debug representation; diagnostic identity only",
+            "player": {"name": "Player", "country": "American", "country_random": True,
+                       "color": 0, "color_claimed": False, "start": "Auto", "team": -1},
+            "opponents": [], "options": {
+                "credits": 10000, "speed": 6, "units": 0, "short_game": True,
+                "super_weapons": True, "build_off_ally": True, "crates": False,
+                "mcv_redeploy": True, "zoom": False,
+            },
+        },
+        "frame": {"path": "frame.bgra", "byte_length": FRAME_BYTES,
+                  "sha256": hashlib.sha256(bytes(FRAME_BYTES)).hexdigest()},
+    }
+
+
+class SkirmishBundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.bundle = Path(self.temp.name)
+        self.frame = self.bundle / "frame.bgra"
+        self.frame.write_bytes(bytes(FRAME_BYTES))
+
+    def write(self, manifest):
+        (self.bundle / "capture.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    def test_valid_diagnostic_bundle_never_claims_parity(self):
+        self.write(fixture())
+        result = validate_bundle(self.bundle)
+        self.assertTrue(result["capture_valid"])
+        self.assertEqual(result["parity_certification"], "NONE")
+
+    def test_rejects_false_claims_and_malformed_route_selection(self):
+        changes = [
+            ("parity_certification", "PASS"), ("reveals_completed", False),
+            ("ordinary_skirmish_frame", False), ("capture_frame", 40),
+            ("checkpoint", "main-menu-0xe2-steady"), ("selection", None),
+            ("route", []), ("capture_frame", True),
+        ]
+        for key, value in changes:
+            with self.subTest(key=key, value=value):
+                manifest = fixture()
+                manifest[key] = value
+                self.write(manifest)
+                with self.assertRaises(ValidationError):
+                    validate_bundle(self.bundle)
+        manifest = fixture()
+        manifest["selection"]["player"] = {}
+        self.write(manifest)
+        with self.assertRaises(ValidationError):
+            validate_bundle(self.bundle)
+
+    def test_rejects_frame_corruption_truncation_and_extra_files(self):
+        self.write(fixture())
+        with self.frame.open("r+b") as stream:
+            stream.write(b"corruption")
+        with self.assertRaises(ValidationError):
+            validate_bundle(self.bundle)
+
+        self.frame.write_bytes(b"short")
+        with self.assertRaises(ValidationError):
+            validate_bundle(self.bundle)
+        self.frame.write_bytes(bytes(FRAME_BYTES))
+        (self.bundle / "extra").write_bytes(b"")
+        with self.assertRaises(ValidationError):
+            validate_bundle(self.bundle)
+
+    def test_rejects_float_cursor_and_false_asset_identity(self):
+        for field in ("x", "y"):
+            manifest = fixture()
+            manifest["cursor"][field] = float(manifest["cursor"][field])
+            self.write(manifest)
+            with self.assertRaises(ValidationError):
+                validate_bundle(self.bundle)
+        manifest = fixture()
+        manifest["selection"]["parsed_map_hash_encoding"] = "native asset bytes"
+        self.write(manifest)
+        with self.assertRaises(ValidationError):
+            validate_bundle(self.bundle)
+
+    def test_rejects_duplicate_json_and_payload_path_escape(self):
+        self.write(fixture())
+        path = self.bundle / "capture.json"
+        raw = path.read_text(encoding="utf-8")
+        path.write_text(raw[:-1] + ',"capture_frame": 60}', encoding="utf-8")
+        with self.assertRaises(ValidationError):
+            validate_bundle(self.bundle)
+        manifest = copy.deepcopy(fixture())
+        manifest["frame"]["path"] = "../frame.bgra"
+        self.write(manifest)
+        with self.assertRaises(ValidationError):
+            validate_bundle(self.bundle)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Skirmish lacked a repeatable capture of its production screen. Add `skirmish-0x102-steady`, which follows the normal Main Menu → Single Player → Skirmish actions after presented frames, waits for transitions and text reveals, and records the next final swapchain frame with its selection state. Add an independent diagnostic artifact validator and stop completed capture sessions before another render callback.

The artifact explicitly reports no parity certification; native input enrollment and reference comparison remain required. Existing main-menu serialization and comparison contracts are preserved. A fresh independent read-only critic reviewed the design, diff, production output and validation; all findings were corrected. This diagnostic increment introduces no new native identity warranting Ghidra annotations.

Validation:
- Full Rust library suite: 8,688 passed; 121 ignored.
- Clippy completed successfully (1,147 warnings).
- Python capture tooling: 63 tests run: 62 passed, one optional evidence test skipped.
- Two hidden skirmish runs produced identical final frame bytes; the corrected run exited cleanly, with recorded input hashes unchanged.
- Existing main-menu capture passed its original validator; invalid dimensions, cursor, developer shortcut and output overwrite were rejected.
- Documentation links, system-map check and diff whitespace check passed.
