### PR TITLE
Keep retail frontend sizing independent of match resolution

### DIFF
--- a/docs/plans/2026-08-31-options-profile-transaction-design.md
+++ b/docs/plans/2026-08-31-options-profile-transaction-design.md
@@ -6,6 +6,12 @@ Phase: 14, rows 299-300 (`GSI-03.02`, `GSI-17.06`)
 
 Status: APPROVED by final corrective `/design-review`; implementation-ready
 
+September 12 correction: this historical design incorrectly equated the early
+configured game pair with the frontend window pair. Fresh original instructions
+establish separate sizes and a post-load mode change. The sizing claims below
+are superseded by [the shell resolution lifecycle evidence](../research/skirmish-ui/2026-09-12-shell-resolution-lifecycle.md);
+the profile read/write and audio contracts remain separate concerns.
+
 ## Goal
 
 Replace VERA20k's fragmented startup/options/audio persistence with one process-lifetime, Rust-native profile transaction that matches the active-YR `OptionsClass` defaults, typed load, consumer application, accepted-dialog ordering, and coherent write boundary.

--- a/docs/research/skirmish-ui/2026-09-12-shell-resolution-lifecycle.md
+++ b/docs/research/skirmish-ui/2026-09-12-shell-resolution-lifecycle.md
@@ -1,0 +1,112 @@
+# Frontend and match resolution lifecycle
+
+Ordinary configured game resolution must not size the frontend. The saved-map
+runtime check exposed overlapping Skirmish/Choose Map controls when Rust applied
+`ScreenWidth=640`, `ScreenHeight=480` at startup. Retail normally runs those
+screens at 800x600 and uses the configured pair after reading a scenario.
+
+## Evidence and acceptance
+
+Original `gamemd.exe` SHA-256
+`1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c`:
+
+- `OptionsClass::SetDefaults` `0x005FA3D0/0x005FA3D7` sets the independent
+  frontend pair `+0x2C/+0x30` to 800/600. Global initializer `0x004E7E20`
+  supplies `A8EB60`, giving shell pair `A8EB8C/90`; game pair is `A8EB84/88`.
+- WinMain reads `Video/AllowModeToggle` with default false at
+  `0x006BC0E6..0x006BC0FC`. False takes `0x006BDAF9`, using the shell pair for
+  window creation and video setup. True takes the distinct 640x480 startup
+  branch `0x006BD9C2`. Display failure also has a fallback branch.
+- Skirmish `0x006AE2C0` and chooser `0x005E68A0` inherit the live frontend
+  dimensions through common dialog hosting `0x0060C4A0`; neither promotes a
+  configured 640x480 game to 800x600 on entry.
+- `Start_Scenario` calls `Read_Scenario` at `0x00683D21`, then compares the
+  game pair and changes mode at `0x00683DBB..0x00683DF3`. Loading resources,
+  progress and their cleanup precede that return. Changing at loading start
+  would incorrectly change loading artwork sizing.
+- Victory restore `0x006857AE..0x006857E5` reads the shell pair without an
+  AllowModeToggle guard. Its exact predicate requires both dimensions to differ;
+  this observation must not be generalized to every exit caller. Ordinary
+  640x480 and 1024x768 matches return to 800x600.
+
+An independent read-only evidence reviewer and the implementation owner checked
+the original sizing branches. This establishes static behavior, not native
+rendered parity.
+
+Acceptance for this ordinary-flow increment:
+
+1. Game preferences 640x480, 800x600 and 1024x768 keep Main Menu → Single Player
+   → Skirmish → Choose Map at 800x600, with drawing and hit testing aligned.
+2. Loading artwork keeps frontend size; successful installation changes to the
+   configured game size before camera/cursor/shroud setup. Native loading failure
+   does not request game mode; the existing generic fallback instead installs
+   its fallback map and enters game mode. Score entry and match return restore
+   frontend size.
+3. Launcher resolution edits retain the new game preference without resizing
+   the frontend, and the next successful match installation consumes it.
+4. Gameplay upscaling cannot change frontend layout or pointer mapping.
+5. Sealed capture dimensions override both frontend and match transitions.
+
+## Implementation boundary
+
+`RetailOptionsLoad` carries an explicitly named startup shell size alongside the
+retained profile. Existing two-pass game preference fallback/readback remains
+intact. `PlatformState` retains the frontend return target and an optional sealed
+capture size, while `PersistenceState.options_profile` remains the sole mutable
+game preference. Common successful `apply_map_load_result` enters game mode;
+individual Skirmish launch handlers no longer own that transition.
+
+Window mode application reads back the actual client size even when winit
+returns `None`: the installed winit 0.30.12 Windows implementation calls
+SetWindowPos and returns `None`. Surface/depth sizing must not wait for the later
+queued resize notification before tactical resource setup. Runtime checks must
+confirm this handoff on the supported Windows target.
+
+Frontend/result projections use window pixels. Loading retains tactical
+projection for pending camera and shroud installation; loading artwork explicitly
+uses GPU/window dimensions. This preserves the existing gameplay upscaler while
+removing its accidental influence over frontend drawing.
+
+## Validation state
+
+The final library suite passed: **8,695 passed, 0 failed, 121 ignored** (18.73 s).
+Clippy completed successfully with 1,150 repository warnings. Regressions cover
+ordinary configured pairs, retained launcher preference, explicit mode-toggle
+startup, frontend/upscaler separation, actual resize readback and capture startup
+isolation. Fresh independent criticism found missing score-entry restoration;
+the correction is included in this final candidate and was independently
+rechecked against the original score caller.
+
+Release SHA-256
+`ef570d036d1db4e9b9ef3c828f2f24db6c302334e40ddf58d524b39d8bfcb276`
+passed isolated production checks: a 640x480 game preference retained 800x600
+frontend/chooser/loading, then applied 640x480 before tactical installation and
+returned to 800x600 through Abort Mission. A 1024x768 preference with a 640x480
+gameplay upscaler source retained frontend/chooser/loading at 800x600, applied
+1024x768 before installation, accepted pointer selection and deployment, then
+returned to 800x600 for score entry and Continue. Captures and surface logs were
+retained locally. The ordinary AutoLocalStart route used its existing compatibility
+bootstrap; these observations do not certify that bootstrap's native semantics.
+
+The sealed 800x600 Skirmish capture passed its artifact validator and retained
+the prior `fe7d42bfebaca25a608e1be3485a2f2f576beca75867ae4961a73a546c42f8fa`
+frame hash. This is a Rust capture nonregression, not a native frame comparison.
+An initial missing-data loading failure also retained frontend size; adding the
+verified retail executable data to the isolated fixture and restarting enabled
+the successful match checks.
+
+Launcher options opened/returned without resizing the frontend, but its existing
+clipped layout prevented manual resolution selection. The profile/launcher
+storage boundary is source- and regression-tested; complete launcher UI acceptance
+remains open. Runtime also exposed existing RA2MD.INI write failures from a
+retained file mapping, and the pause menu's developer overlay. These ordinary
+findings belong to the remaining shell/persistence work, not a resolved-parity
+claim for this increment.
+
+Fresh independent read-only criticism passed the final evidence, design, diff and
+validation with the stated scope limits. Independently confirmed comments were
+appended at `0x005FA350`, `0x006BB9A0`, `0x00683AB0` and `0x00685670`, preserving
+existing comments and labels; the program was saved and all four readbacks matched.
+This increment does not close all-shell acceptance. Explicit mode-toggle runtime, fullscreen/video
+failure, unusual one-axis exit predicates and platform backends other than
+Windows remain separately bounded coverage.

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -50,12 +50,26 @@ impl ShellWindowModeOperations for PlatformShellWindowModeOperations<'_> {
 }
 
 fn enter_shell_window_mode_with_operations(operations: &mut impl ShellWindowModeOperations) {
-    operations.set_resizable(false);
     let target = operations.shell_client_size();
+    apply_window_mode(operations, target, false);
+}
+
+fn apply_window_mode(
+    operations: &mut impl ShellWindowModeOperations,
+    target: PhysicalSize<u32>,
+    resizable: bool,
+) {
+    operations.set_resizable(resizable);
     if operations.inner_size() == target {
         return;
     }
-    if let Some(applied_size) = operations.request_inner_size(target) {
+    // winit 0.30.12 Windows calls SetWindowPos but returns None. Read the
+    // actual client size before installing size-dependent tactical resources;
+    // waiting solely for its queued Resized event would use the old shell size.
+    let applied_size = operations
+        .request_inner_size(target)
+        .unwrap_or_else(|| operations.inner_size());
+    if applied_size.width != 0 && applied_size.height != 0 {
         operations.resize_surface_for_window_size(applied_size);
     }
     operations.request_redraw();
@@ -72,7 +86,10 @@ impl App {
     fn resize_surface_for_window_size(state: &mut AppState, size: PhysicalSize<u32>) {
         state.renderer.gpu.resize(size.width, size.height);
         state.renderer.depth_view = state.renderer.gpu.create_depth_texture();
-        state.renderer.shell_surface_presenter.resize(&state.renderer.gpu);
+        state
+            .renderer
+            .shell_surface_presenter
+            .resize(&state.renderer.gpu);
         // The frame-index wave is driven by wall-clock ticks and repaints every
         // frame, so a mid-flight resize simply lets it finish; no snap/cancel.
         Self::invalidate_main_menu_movie_if_base_changed(state);
@@ -82,10 +99,35 @@ impl App {
     pub(crate) fn enter_shell_window_mode(state: &mut AppState) {
         let mut operations = PlatformShellWindowModeOperations { state };
         enter_shell_window_mode_with_operations(&mut operations);
+        log::info!(
+            "Frontend surface {}x{}",
+            state.renderer.gpu.config.width, state.renderer.gpu.config.height,
+        );
     }
 
-    pub(super) fn enter_game_window_mode(state: &AppState) {
-        state.platform.window.set_resizable(true);
+    pub(crate) fn enter_game_window_mode(state: &mut AppState) {
+        // Scenario start 00683DBB..00683DF3 applies the game pair; shell return
+        // 006857AE restores the independent frontend pair. Profile stays sole
+        // authority, so launcher resolution edits take effect on the next match.
+        let size = state.persistence.options_profile.game_screen_size();
+        let target = state
+            .platform
+            .capture_client_size
+            .unwrap_or_else(|| PhysicalSize::new(size.width, size.height));
+        // Explicit low-mode startup is not a permanent return preference:
+        // 006857AE restores Options' independent frontend pair after a match.
+        let shell = crate::app::persistence::options_profile::RETAIL_SHELL_SIZE;
+        state.platform.shell_client_size = state
+            .platform
+            .capture_client_size
+            .unwrap_or_else(|| PhysicalSize::new(shell.width, shell.height));
+        let mut operations = PlatformShellWindowModeOperations { state };
+        apply_window_mode(&mut operations, target, true);
+        log::info!(
+            "Match surface {}x{} (requested {}x{})",
+            state.renderer.gpu.config.width, state.renderer.gpu.config.height,
+            target.width, target.height,
+        );
     }
 }
 
@@ -132,6 +174,9 @@ mod tests {
 
         fn request_inner_size(&mut self, size: PhysicalSize<u32>) -> Option<PhysicalSize<u32>> {
             self.requested_sizes.push(size);
+            if self.applied_size.is_none() {
+                self.current_size = size;
+            }
             self.applied_size
         }
 
@@ -165,6 +210,33 @@ mod tests {
         assert!(equal.requested_sizes.is_empty());
         assert!(equal.resized_surfaces.is_empty());
         assert_eq!(equal.redraw_requests, 0);
+    }
+
+    #[test]
+    fn windows_none_resize_result_reads_back_the_applied_client_size() {
+        let shell = PhysicalSize::new(800, 600);
+        let game = PhysicalSize::new(640, 480);
+        let mut operations = RecordingShellWindowModeOperations::new(shell, shell);
+        operations.applied_size = None;
+        apply_window_mode(&mut operations, game, true);
+        assert_eq!(operations.resized_surfaces, [game]);
+        enter_shell_window_mode_with_operations(&mut operations);
+        assert_eq!(operations.requested_sizes, [game, shell]);
+        assert_eq!(operations.resized_surfaces, [game, shell]);
+    }
+
+    #[test]
+    fn game_mode_applies_the_returned_physical_size_before_resource_installation() {
+        let shell = PhysicalSize::new(800, 600);
+        let game = PhysicalSize::new(1024, 768);
+        let applied = PhysicalSize::new(1000, 740);
+        let mut operations = RecordingShellWindowModeOperations::new(shell, shell);
+        operations.applied_size = Some(applied);
+        apply_window_mode(&mut operations, game, true);
+        assert_eq!(operations.resizable_values, [true]);
+        assert_eq!(operations.requested_sizes, [game]);
+        assert_eq!(operations.resized_surfaces, [applied]);
+        assert_eq!(operations.redraw_requests, 1);
     }
 
     #[test]

--- a/src/app/in_game.rs
+++ b/src/app/in_game.rs
@@ -701,6 +701,9 @@ impl App {
                 state.frontend.score_screen = Some(model);
                 state.frontend.score_shell_state = Default::default();
                 state.frontend.screen = GameScreen::MissionResult { title, detail };
+                // Victory 006857AE restores the shell pair before score
+                // construction/run at 00685884/0068588B, not after Continue.
+                Self::enter_shell_window_mode(state);
             }
             Some(crate::app::match_runtime::scenario_exit::ScenarioExitDestination::MainMenu) => {
                 Self::return_to_main_menu(state);

--- a/src/app/initialize.rs
+++ b/src/app/initialize.rs
@@ -113,7 +113,7 @@ impl App {
         startup_options: RetailStartupOptions,
     ) -> Result<AppState> {
         // One parsed retail profile snapshot yields two ordered products: the
-        // early Video/fallback pair that selects the window, and the later
+        // independent frontend size selected after the early Video read, and the later
         // full-read profile retained by persistence. Capture is a sealed
         // automation lane, so it uses exact defaults and its explicit
         // dimensions instead of ingesting operator argv/profile screen state.
@@ -126,7 +126,7 @@ impl App {
                 .map(|config| config.paths.ra2_dir.as_path()),
             RetailOptionsLoad::from_ra2md,
         );
-        let profile_screen = options_load.startup_screen;
+        let profile_screen = options_load.startup_shell_screen;
         let options_profile = options_load.retained_profile;
         let (window_width, window_height, window_visible) =
             startup_window_projection(profile_screen, capture_dimensions);
@@ -482,7 +482,12 @@ impl App {
         }
 
         let mut state = AppState {
-            platform: PlatformState::new(window, game_config, shell_client_size),
+            platform: PlatformState::new(
+                window,
+                game_config,
+                shell_client_size,
+                capture_dimensions.map(|(w, h)| PhysicalSize::new(w, h)),
+            ),
             match_state: crate::app::match_runtime::state::MatchState {
                 startup: Default::default(),
                 sim_runtime: None,
@@ -1024,7 +1029,7 @@ mod tests {
                 score_volume: 0.3,
                 ..Default::default()
             },
-            startup_screen: ScreenSize {
+            startup_shell_screen: ScreenSize {
                 width: 640,
                 height: 480,
             },
@@ -1046,11 +1051,11 @@ mod tests {
             RetailOptionsLoad::without_ra2md(&RetailStartupOptions::default())
         );
         assert_eq!(
-            startup_window_projection(options_load.startup_screen, capture_dimensions),
+            startup_window_projection(options_load.startup_shell_screen, capture_dimensions),
             (1024, 768, false)
         );
         assert_eq!(
-            options_load.startup_screen,
+            options_load.startup_shell_screen,
             ScreenSize {
                 width: 800,
                 height: 600,

--- a/src/app/loading/transitions.rs
+++ b/src/app/loading/transitions.rs
@@ -111,6 +111,10 @@ pub(crate) fn fallback_map_load_result() -> init::MapLoadResult {
 }
 
 pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadResult) {
+    // Start_Scenario 00683D21 completes Read_Scenario before switching video
+    // mode at 00683DF3. Loading artwork stays at shell size; successful tactical
+    // installation must size its camera/shroud against the applied game mode.
+    crate::app::App::enter_game_window_mode(state);
     crate::app::reset_scenario_exit_runtime(state);
     let startup = result.scenario.startup;
     let returns_scenario_rng_to_offline_shell = startup.launch_session().is_some();

--- a/src/app/persistence/options_profile.rs
+++ b/src/app/persistence/options_profile.rs
@@ -2,7 +2,7 @@
 //!
 //! This module translates the active-YR `OptionsClass` profile boundary into
 //! one ordinary Rust value. It owns exact defaults, typed `RA2MD.INI` loading,
-//! startup screen-pair resolution, native-shaped formatting, and the one-read /
+//! separate game-pair resolution and frontend selection, native-shaped formatting, and the one-read /
 //! one-write preservation-safe commit. Runtime consumers remain in their
 //! existing app, presentation, and audio owners.
 
@@ -21,6 +21,10 @@ const AUDIO_SECTION: &str = "Audio";
 const SCREEN_SIZE_UNSET: i32 = -1;
 const DEFAULT_SCREEN_WIDTH: i32 = 800;
 const DEFAULT_SCREEN_HEIGHT: i32 = 600;
+pub(crate) const RETAIL_SHELL_SIZE: ScreenSize = ScreenSize {
+    width: 800,
+    height: 600,
+};
 
 /// The process-lifetime subset of active-YR `OptionsClass` owned by
 /// `RA2MD.INI` `[Options]`, `[Video]`, and `[Audio]`.
@@ -69,13 +73,13 @@ pub(crate) struct RetailOptionsProfile {
 /// The two process-start products obtained from one physical `RA2MD.INI`
 /// snapshot.
 ///
-/// Native selects the startup window after an early Video-only read, then
-/// rereads the complete profile later. Keeping both products explicit avoids
-/// making the retained profile double as a historical window decision.
+/// Native resolves the game preference after an early Video read, separately
+/// selects the frontend window, then rereads the complete profile later.
+/// Keeping both products explicit prevents game settings from sizing the shell.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct RetailOptionsLoad {
     pub(crate) retained_profile: RetailOptionsProfile,
-    pub(crate) startup_screen: ScreenSize,
+    pub(crate) startup_shell_screen: ScreenSize,
 }
 
 impl Default for RetailOptionsProfile {
@@ -187,7 +191,21 @@ impl RetailOptionsLoad {
         if let Some(ini) = ini {
             retained_profile.apply_startup_video_ini(ini);
         }
-        let startup_screen = retained_profile.resolve_screen_size();
+        retained_profile.resolve_screen_size();
+        // WinMain 006BD9B5 selects the independent shell pair A8EB8C/90
+        // (defaults 800x600 at 005FA3D0), not the configured game pair.
+        // Explicit AllowModeToggle takes the separate 640x480 startup branch.
+        let allow_mode_toggle = ini
+            .and_then(|ini| ini.section(VIDEO_SECTION))
+            .is_some_and(|video| video.read_bool("AllowModeToggle", false));
+        let startup_shell_screen = if allow_mode_toggle {
+            ScreenSize {
+                width: 640,
+                height: 480,
+            }
+        } else {
+            RETAIL_SHELL_SIZE
+        };
 
         // Retail provenance: the complete `OptionsClass__ReadFromINI` @
         // `0x005FA620`, called by `Init_Game` at `0x0052C630`. Reusing the
@@ -199,7 +217,7 @@ impl RetailOptionsLoad {
 
         Self {
             retained_profile,
-            startup_screen,
+            startup_shell_screen,
         }
     }
 }
@@ -294,6 +312,12 @@ impl RetailOptionsProfile {
             self.screen_width = DEFAULT_SCREEN_WIDTH;
             self.screen_height = DEFAULT_SCREEN_HEIGHT;
         }
+        self.game_screen_size()
+    }
+
+    /// Current match preference, including launcher edits, projected only at
+    /// the platform boundary. Scenario start 00683DBB reads A8EB84/88 here.
+    pub(crate) fn game_screen_size(&self) -> ScreenSize {
         ScreenSize {
             width: self.screen_width.max(1) as u32,
             height: self.screen_height.max(1) as u32,
@@ -553,7 +577,7 @@ mod tests {
 
         assert_eq!(reads.get(), 1, "both semantic reads share one snapshot");
         assert_eq!(
-            load.startup_screen,
+            load.startup_shell_screen,
             ScreenSize {
                 width: 800,
                 height: 600,
@@ -580,7 +604,7 @@ mod tests {
         );
 
         assert_eq!(
-            load.startup_screen,
+            load.startup_shell_screen,
             ScreenSize {
                 width: 800,
                 height: 600,
@@ -596,17 +620,62 @@ mod tests {
     }
 
     #[test]
-    fn full_screen_pair_selects_and_retains_the_same_size() {
+    fn ordinary_frontend_size_is_independent_of_game_profile_and_launcher_edits() {
+        for (width, height) in [(640, 480), (800, 600), (1024, 768)] {
+            let ini = format!("[Video]\nScreenWidth={width}\nScreenHeight={height}\n");
+            let mut load = load_snapshot(&RetailStartupOptions::default(), ini.as_bytes());
+            assert_eq!(load.startup_shell_screen, RETAIL_SHELL_SIZE);
+            assert_eq!(
+                load.retained_profile.game_screen_size(),
+                ScreenSize { width, height }
+            );
+            load.retained_profile.screen_width = 1280;
+            load.retained_profile.screen_height = 960;
+            assert_eq!(
+                load.retained_profile.game_screen_size(),
+                ScreenSize {
+                    width: 1280,
+                    height: 960
+                }
+            );
+            assert_eq!(load.startup_shell_screen, RETAIL_SHELL_SIZE);
+        }
+    }
+
+    #[test]
+    fn explicit_mode_toggle_selects_low_startup_without_replacing_game_preference() {
+        let load = load_snapshot(
+            &RetailStartupOptions::default(),
+            b"[Video]\nAllowModeToggle=yes\nScreenWidth=1024\nScreenHeight=768\n",
+        );
+        assert_eq!(
+            load.startup_shell_screen,
+            ScreenSize {
+                width: 640,
+                height: 480
+            }
+        );
+        assert_eq!(
+            load.retained_profile.game_screen_size(),
+            ScreenSize {
+                width: 1024,
+                height: 768
+            }
+        );
+    }
+
+    #[test]
+    fn configured_game_pair_does_not_select_the_shell_size() {
         let load = load_snapshot(
             &RetailStartupOptions::default(),
             b"[Video]\nScreenWidth=640\nScreenHeight=480\n",
         );
 
         assert_eq!(
-            load.startup_screen,
+            load.startup_shell_screen,
             ScreenSize {
-                width: 640,
-                height: 480,
+                width: 800,
+                height: 600,
             }
         );
         assert_eq!(
@@ -628,10 +697,10 @@ mod tests {
         let load = load_snapshot(&startup, b"[Video]\nScreenWidth=640\n");
 
         assert_eq!(
-            load.startup_screen,
+            load.startup_shell_screen,
             ScreenSize {
-                width: 640,
-                height: 768,
+                width: 800,
+                height: 600,
             }
         );
         assert_eq!(
@@ -644,10 +713,10 @@ mod tests {
 
         let missing_both = load_snapshot(&startup, b"[Options]\nGameSpeed=4\n");
         assert_eq!(
-            missing_both.startup_screen,
+            missing_both.startup_shell_screen,
             ScreenSize {
-                width: 1024,
-                height: 768,
+                width: 800,
+                height: 600,
             }
         );
         assert_eq!(
@@ -670,10 +739,10 @@ mod tests {
             Err(io::Error::new(io::ErrorKind::NotFound, "missing"))
         });
         assert_eq!(
-            missing.startup_screen,
+            missing.startup_shell_screen,
             ScreenSize {
-                width: 1024,
-                height: 768,
+                width: 800,
+                height: 600,
             }
         );
         assert_eq!(
@@ -691,7 +760,7 @@ mod tests {
         };
         let partial = RetailOptionsLoad::without_ra2md(&partial);
         assert_eq!(
-            partial.startup_screen,
+            partial.startup_shell_screen,
             ScreenSize {
                 width: 800,
                 height: 600,
@@ -714,10 +783,10 @@ mod tests {
         );
 
         assert_eq!(
-            load.startup_screen,
+            load.startup_shell_screen,
             ScreenSize {
-                width: 1,
-                height: 480,
+                width: 800,
+                height: 600,
             }
         );
         assert_eq!(

--- a/src/app/shell_skirmish.rs
+++ b/src/app/shell_skirmish.rs
@@ -217,7 +217,6 @@ impl App {
             state.frontend.skirmish_settings.clone(),
         );
         crate::app::loading::pump::begin_loading(state, request);
-        Self::enter_game_window_mode(state);
         state.match_state.input.zoom_level = 1.0;
         state.match_state.input.zoom_target = 1.0;
     }
@@ -271,7 +270,6 @@ impl App {
         state.frontend.shell_first_paint_slide = None;
         state.frontend.skirmish_preview_texture = None;
         crate::app::loading::pump::begin_loading(state, request);
-        Self::enter_game_window_mode(state);
         state.match_state.input.zoom_level = 1.0;
         state.match_state.input.zoom_target = 1.0;
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -50,18 +50,23 @@ pub(crate) fn reset_scenario_exit_runtime(state: &mut AppState) {
 }
 
 impl AppState {
-    /// Effective render target width — intermediate texture when upscaling, else window.
-    pub(crate) fn render_width(&self) -> u32 {
-        self.renderer.upscale_pass
-            .as_ref()
-            .map_or(self.renderer.gpu.config.width, |u| u.src_width())
+    /// Current projection: frontend/result use physical window pixels; tactical
+    /// rendering and pending tactical installation use the optional upscaler.
+    /// Loading artwork explicitly uses GPU/window dimensions in loading::pump.
+    fn render_dimensions(&self) -> (u32, u32) {
+        platform::render_dimensions(
+            &self.frontend.screen,
+            (self.renderer.gpu.config.width, self.renderer.gpu.config.height),
+            self.renderer.upscale_pass.as_ref().map(|up| (up.src_width(), up.src_height())),
+        )
     }
 
-    /// Effective render target height — intermediate texture when upscaling, else window.
+    pub(crate) fn render_width(&self) -> u32 {
+        self.render_dimensions().0
+    }
+
     pub(crate) fn render_height(&self) -> u32 {
-        self.renderer.upscale_pass
-            .as_ref()
-            .map_or(self.renderer.gpu.config.height, |u| u.src_height())
+        self.render_dimensions().1
     }
 
     /// Whether the software cursor (mouse.shp) should be active this frame.

--- a/src/app/state/platform.rs
+++ b/src/app/state/platform.rs
@@ -7,6 +7,51 @@ use winit::dpi::PhysicalSize;
 use winit::window::Window;
 
 use crate::app::match_runtime::frame_pacer::LocalFramePacer;
+use crate::ui::game_screen::GameScreen;
+
+/// Loading uses tactical dimensions only for pending match-resource setup;
+/// its own artwork uses the window directly. Frontend layout and hit testing
+/// must never inherit a gameplay upscaler's source size.
+pub(super) fn render_dimensions(
+    screen: &GameScreen,
+    window: (u32, u32),
+    tactical_source: Option<(u32, u32)>,
+) -> (u32, u32) {
+    match screen {
+        GameScreen::MainMenu | GameScreen::MissionResult { .. } => window,
+        GameScreen::Loading | GameScreen::SpawnPick | GameScreen::InGame => {
+            tactical_source.unwrap_or(window)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gameplay_upscaling_never_changes_frontend_projection() {
+        let window = (800, 600);
+        let source = (640, 480);
+        for screen in [
+            GameScreen::MainMenu,
+            GameScreen::MissionResult {
+                title: String::new(),
+                detail: String::new(),
+            },
+        ] {
+            assert_eq!(render_dimensions(&screen, window, Some(source)), window);
+        }
+        for screen in [
+            GameScreen::Loading,
+            GameScreen::SpawnPick,
+            GameScreen::InGame,
+        ] {
+            assert_eq!(render_dimensions(&screen, window, Some(source)), source);
+            assert_eq!(render_dimensions(&screen, window, None), window);
+        }
+    }
+}
 
 /// Window lifecycle and wall-clock pacing owned by the platform layer.
 ///
@@ -40,9 +85,11 @@ pub(crate) struct PlatformState {
     /// mutated afterwards.
     pub(crate) game_config: Option<crate::util::config::GameConfig>,
     /// Effective shell client size for this process. Interactive launches use
-    /// the resolved retail profile pair; sealed captures retain their explicit
+    /// the independent retail frontend pair; sealed captures retain their explicit
     /// dimensions as the higher-priority automation projection.
     pub(crate) shell_client_size: PhysicalSize<u32>,
+    /// Sealed captures keep their requested surface through match launch too.
+    pub(crate) capture_client_size: Option<PhysicalSize<u32>>,
 }
 
 impl PlatformState {
@@ -50,6 +97,7 @@ impl PlatformState {
         window: Arc<Window>,
         game_config: Option<crate::util::config::GameConfig>,
         shell_client_size: PhysicalSize<u32>,
+        capture_client_size: Option<PhysicalSize<u32>>,
     ) -> Self {
         Self {
             window,
@@ -59,6 +107,7 @@ impl PlatformState {
             frame_pacer: LocalFramePacer::new(),
             game_config,
             shell_client_size,
+            capture_client_size,
         }
     }
 }


### PR DESCRIPTION
Configured 640x480 gameplay previously shrank the frontend and overlapped Skirmish controls. Keep ordinary menus and loading at the retail 800x600 shell size, apply the current game preference after successful loading, and restore the shell before scores or menu return. Frontend drawing now ignores gameplay upscaling; the shared transition reads back the applied Windows client size before tactical setup.

Original instructions establish the separate defaults, startup branch, post-load switch and pre-score restoration. Fresh independent read-only review passed evidence, design, final diff and validation after correcting score-entry restoration. Four independently confirmed Ghidra comments were saved and read back.

Validation: 8,695 library tests passed, 121 ignored; Clippy completed with 1,150 existing repository warnings. Production checks covered 640x480 and 1024x768 matches, loading size, abort/score/continue restoration, and frontend isolation from a 640x480 gameplay upscaler. The sealed 800x600 Skirmish capture passed and retained its prior frame hash.

This is scoped lifecycle acceptance. Native pixel parity, clipped launcher layout/manual resolution selection, profile mapping write failures and exceptional display paths remain open and are documented in the evidence report.
