### PR TITLE
Allow shell persistence while the asset manager remains alive

### DIFF
--- a/docs/research/skirmish-ui/2026-09-12-mutable-loose-files.md
+++ b/docs/research/skirmish-ui/2026-09-12-mutable-loose-files.md
@@ -1,0 +1,98 @@
+# Loose asset storage and shell persistence
+
+Ordinary Skirmish Start and Options close failed to save `RA2MD.INI` on Windows
+with error 1224: a user-mapped section was open. The process-owned `AssetManager`
+indexed every regular file in the retail root by opening a lifetime memory
+mapping, including the profile, saved seeds and generated previews. Its intended
+lifetime across menus and matches made these write failures persistent.
+
+## Acceptance and ownership
+
+Keep the process asset manager alive while Skirmish and Options alternately
+write the same existing profile. Both owners' latest values and unrelated file
+content must survive. Existing saved seeds and generated preview files must be
+overwritable, and subsequent direct readers must see the current bytes.
+
+Preserve loose-before-MIX byte precedence, stable borrowed asset bytes, empty
+file resolution, fallback to MIX when the loose payload cannot be read, and the
+separate process-sticky CRC cache. Indexing and availability probes must not read
+every archive/movie payload into memory.
+
+`LooseAsset` now retains a path and a lazy owned byte snapshot. The first byte
+lookup closes its file handle after reading. Borrowers therefore keep stable
+storage without retaining a mapping of a file that another owner can truncate.
+All byte lookup APIs share this boundary; a failed loose read falls through to
+MIX. Archive storage and `LoadFileFromMIX` cache ownership remain unchanged.
+
+This is a Rust storage policy, not an emulation of native raw-file caching.
+The startup filename catalog remains fixed; each first read, including failure,
+is retained for that manager's lifetime. `contains` checks catalog presence
+without loading bytes and is not a guarantee that a future disk read succeeds.
+Live asset hot reload and retry behavior are outside this increment.
+
+Ordinary mutable consumers already read disk directly: Options profile and
+Skirmish persistence, saved-seed browser and generation, generated preview
+loading, and the ordinary map loader's disk-first branch. They do not consume
+the asset snapshot as their mutable state authority. No per-writer retry or
+mutable-file extension allowlist is introduced.
+
+## Original evidence
+
+Original `gamemd.exe` SHA-256:
+`1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c`.
+
+- Options writer `0x005FAD10` constructs a stack CCFile at `0x005FAD22` with
+  literal `RA2MD.INI` at `0x00826444`. It writes through `0x00474430` at
+  `0x005FB007` and tears down the file object at `0x005FB027/0x005FB038`.
+- The active launcher dialog loop calls that writer at `0x0055FD8E` after its
+  primary/child routing. The in-game accepted Options path calls it at
+  `0x004E1DAB`; independent review checked that caller's acceptance branch.
+- The INI writer uses FilePipe: `0x007BA480` opens with mode 2 at
+  `0x007BA4AC/0x007BA4B0`; its destructor `0x007BA420` conditionally closes a
+  file it opened through virtual slot `+0x34`.
+- CCFile open `0x00473D10` tests mode bit 2 at `0x00473D1D`, routing writes to
+  `0x00473E39` and buffered/raw open instead of MIX resolution. Raw open
+  `0x0065CB50` takes the mode-2 branch at `0x0065CB94`: write access, no sharing,
+  create-always. This establishes short-lived physical write ownership; it
+  does not establish equivalence of Rust's asset snapshot policy.
+
+The original instructions, filename bytes and active callers were independently
+checked. Existing labels served as leads. No native executable was modified.
+
+## Validation state
+
+The final library suite passed **8,698 tests, 0 failed, 121 ignored** (18.05 s).
+Clippy completed successfully with 1,150 repository warnings (23.15 s).
+Regressions exercise live-manager profile/seed writers, lazy stable loose
+payloads with truncation, empty files, and failed-read fallback across byte APIs.
+The first focused run exposed an out-of-range test seed (424242); using 42424
+keeps this persistence test within the existing 16-bit normalization contract.
+No seed behavior was changed.
+
+Release SHA-256
+`833bb2fae5cb4e2ad4f3233b0dee501fc1f761b83abdaafe4a5c052f8d282ba3`
+passed isolated Windows production checks. Skirmish Start persisted Credits=6900;
+the loaded match used that value. Game Controls close persisted ScrollRate=2.
+After Abort returned to the shell, launcher acceptance persisted ScoreVolume=0.3.
+The other owners' values and an unrelated sentinel section survived every write.
+A fresh process restored those visible settings.
+
+The saved-map browser overwrote an existing `SCROLL01.SED` (seed 42 to 56613)
+and displayed Map Saved. Accepting the generated result replaced an existing
+`RandMap.Sed` and nonempty `RandMap.img` fixture with the generated seed and
+PCX-encoded preview. After restart the browser loaded the overwritten seed,
+regenerated its preview and replaced both working files again. Captures, before/
+after profile snapshots and file hashes were retained locally. The run's logs
+contained no profile/seed/preview write failure or error 1224. These are production
+persistence checks, not a native frame or random-map determinism comparison.
+
+Fresh independent read-only criticism passed the evidence, design, final diff
+and validation within this scope. Independently confirmed comments were added
+at `0x005FAD10` and appended at `0x00473D10`, preserving existing comments and
+labels. The program was saved and both annotation readbacks matched exactly.
+
+This corrects an ordinary persistence obstruction. It does not certify all
+shell visuals, launcher layout, native raw-file live reload, or the complete
+game-start bootstrap. The existing Game Controls view also exposes missing
+chrome/labels/buttons over tactical art; that ordinary in-game shell gap was
+captured for subsequent rendering work.

--- a/src/app/frontend/skirmish_session.rs
+++ b/src/app/frontend/skirmish_session.rs
@@ -1026,6 +1026,78 @@ Credits=12345\r\n";
         skirmish_global_defaults(&SkirmishShellState::default())
     }
 
+    #[test]
+    fn profile_and_seed_writers_work_with_process_asset_manager_alive() {
+        use crate::app::persistence::options_profile::RetailOptionsProfile;
+        use crate::map::rmg::{RmgOptions, saved_seeds};
+
+        let directory = std::env::temp_dir().join(format!(
+            "vera20k-live-profile-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&directory).expect("fixture directory");
+        let path = directory.join(RA2MD_INI);
+        let initial =
+            b"; keep this comment\r\n[Unrelated]\r\nKey=kept\r\n[Skirmish]\r\nCredits=10000\r\n";
+        std::fs::write(&path, initial).expect("existing nonempty profile");
+        let seed_name = crate::util::native_file_name::NativeFileName::from("SAVE0001.SED");
+        let mut seed = RmgOptions::default();
+        saved_seeds::write_browser_seed(&directory, &seed_name, &seed).expect("existing seed");
+        let assets = AssetManager::from_loose_root_for_test(&directory);
+        let borrowed_profile = assets.get_ref(RA2MD_INI).expect("profile snapshot");
+        let borrowed_seed = assets.get_ref("SAVE0001.SED").expect("seed snapshot");
+        let mut runtime = OfflineSkirmishRuntime::initialize(
+            42,
+            Some(&directory),
+            Some(&assets),
+            None,
+            defaults(),
+        );
+        let mut profile = RetailOptionsProfile::default();
+
+        for (credits, scroll_rate) in [(22000, 3), (33000, 5)] {
+            runtime.snapshot.credits = credits;
+            runtime.persist_snapshot();
+            profile.scroll_rate = scroll_rate;
+            profile
+                .commit_ra2md(&directory)
+                .expect("Options write with manager alive");
+            runtime.persist_snapshot();
+            let bytes = std::fs::read(&path).expect("persisted profile");
+            let ini = IniFile::from_bytes(&bytes).expect("profile INI");
+            assert_eq!(
+                ini.section("Skirmish").unwrap().get("Credits"),
+                Some(credits.to_string().as_str())
+            );
+            assert_eq!(
+                ini.section("Options").unwrap().get("ScrollRate"),
+                Some(scroll_rate.to_string().as_str())
+            );
+            assert_eq!(ini.section("Unrelated").unwrap().get("Key"), Some("kept"));
+            assert!(bytes.starts_with(b"; keep this comment"));
+        }
+
+        seed.seed = 42424;
+        seed.description = "Overwritten".into();
+        saved_seeds::write_browser_seed(&directory, &seed_name, &seed)
+            .expect("overwrite existing seed");
+        let reread = saved_seeds::read_browser_seed(
+            &directory,
+            &seed_name,
+            &RmgOptions::default(),
+            "Random Map",
+        )
+        .expect("read current saved seed");
+        assert_eq!(reread.seed, seed.seed);
+        assert_eq!(reread.description, seed.description);
+        assert_eq!(borrowed_profile, initial);
+        assert_ne!(borrowed_seed, seed.to_sed_bytes());
+        assert_eq!(assets.get_ref(RA2MD_INI), Some(borrowed_profile));
+        drop(assets);
+        std::fs::remove_dir_all(directory).expect("remove owned fixture");
+    }
+
     fn random_session() -> SkirmishLaunchSession {
         SkirmishLaunchSession {
             mode: SkirmishLaunchMode::from_game_mode(&mode()),

--- a/src/assets/asset_manager.rs
+++ b/src/assets/asset_manager.rs
@@ -8,9 +8,8 @@
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::assets::error::AssetError;
 use crate::assets::mix_archive::MixArchive;
@@ -24,28 +23,29 @@ struct NamedArchive {
     archive: MixArchive,
 }
 
-enum LooseBytes {
-    Empty,
-    Mapped(memmap2::Mmap),
-    #[cfg(test)]
-    Owned(Box<[u8]>),
-}
-
-impl LooseBytes {
-    fn as_slice(&self) -> &[u8] {
-        match self {
-            Self::Empty => &[],
-            Self::Mapped(data) => data,
-            #[cfg(test)]
-            Self::Owned(data) => data,
-        }
-    }
-}
-
 struct LooseAsset {
     path: PathBuf,
     source_name: String,
-    bytes: LooseBytes,
+    bytes: OnceLock<Option<Box<[u8]>>>,
+}
+
+impl LooseAsset {
+    /// Borrowed asset APIs need stable storage, but loose files may be rewritten
+    /// by profile/SED/preview owners. A retained mapping prevents Windows writes
+    /// and cannot safely coexist with truncation on other platforms. Snapshot
+    /// only requested payloads; root indexing must not copy entire MIX archives.
+    /// This is Rust storage policy, not native raw-file cache equivalence.
+    fn bytes(&self) -> Option<&[u8]> {
+        self.bytes
+            .get_or_init(|| match std::fs::read(&self.path) {
+                Ok(bytes) => Some(bytes.into_boxed_slice()),
+                Err(err) => {
+                    log::debug!("Skipping loose {}: {}", self.path.display(), err);
+                    None
+                }
+            })
+            .as_deref()
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -151,6 +151,8 @@ pub struct AssetManager {
     /// `LoadFileFromMIX`'s process-lifetime, normalized-CRC first-winner cache.
     mix_file_cache: Mutex<HashMap<i32, MixFileLoad>>,
     /// Case-insensitive, non-recursive view of the retail executable directory.
+    /// Payloads are owned snapshots at first lookup (including failed reads).
+    /// Mutable profile/seed/preview consumers read the filesystem directly.
     loose_files: HashMap<String, LooseAsset>,
     /// Currently registered theater identity and its archive names.
     active_theater: Option<String>,
@@ -317,9 +319,9 @@ impl AssetManager {
 
     /// Look up a file by name across all loaded archives.
     pub fn get(&self, name: &str) -> Option<Vec<u8>> {
-        if let Some(loose) = self.loose_asset(name) {
+        if let Some((loose, bytes)) = self.loose_bytes(name) {
             log::trace!("Found loose '{}' at {}", name, loose.path.display());
-            return Some(loose.bytes.as_slice().to_vec());
+            return Some(bytes.to_vec());
         }
         let (named, entry_id) = self.lookup_asset_entry(name)?;
         log::trace!("Found '{}' in {}", name, named.name);
@@ -328,9 +330,9 @@ impl AssetManager {
 
     /// Look up a file by name without copying the asset bytes.
     pub fn get_ref(&self, name: &str) -> Option<&[u8]> {
-        if let Some(loose) = self.loose_asset(name) {
+        if let Some((loose, bytes)) = self.loose_bytes(name) {
             log::trace!("Found loose '{}' at {}", name, loose.path.display());
-            return Some(loose.bytes.as_slice());
+            return Some(bytes);
         }
         let (named, entry_id) = self.lookup_asset_entry(name)?;
         log::trace!("Found '{}' in {}", name, named.name);
@@ -339,8 +341,8 @@ impl AssetManager {
 
     /// Look up a file by name and return both the bytes and source archive name.
     pub fn get_with_source(&self, name: &str) -> Option<(Vec<u8>, String)> {
-        if let Some(loose) = self.loose_asset(name) {
-            return Some((loose.bytes.as_slice().to_vec(), loose.source_name.clone()));
+        if let Some((loose, bytes)) = self.loose_bytes(name) {
+            return Some((bytes.to_vec(), loose.source_name.clone()));
         }
         let (named, entry_id) = self.lookup_asset_entry(name)?;
         named
@@ -357,9 +359,9 @@ impl AssetManager {
 
     /// Resolve one file through the normal first-match archive lookup.
     pub fn resolve_ref(&self, name: &str) -> Option<AssetResolutionRef<'_>> {
-        if let Some(loose) = self.loose_asset(name) {
+        if let Some((loose, bytes)) = self.loose_bytes(name) {
             return Some(AssetResolutionRef {
-                bytes: loose.bytes.as_slice(),
+                bytes,
                 source_archive: loose.source_name.as_str(),
                 entry_id: mix_hash(name),
             });
@@ -393,9 +395,9 @@ impl AssetManager {
             return Some(cached);
         }
 
-        let candidate = if let Some(loose) = self.loose_asset(name) {
+        let candidate = if let Some((loose, bytes)) = self.loose_bytes(name) {
             MixFileLoad {
-                bytes: Arc::from(loose.bytes.as_slice()),
+                bytes: Arc::from(bytes),
                 source_archive: Arc::from(loose.source_name.as_str()),
                 entry_id: cache_key,
             }
@@ -496,9 +498,7 @@ impl AssetManager {
                 Ok(true) => self.active_theater_archives.push(name.to_string()),
                 Ok(false) => {}
                 Err(err) => {
-                    log::warn!(
-                        "Theater {theater_name}: skipping optional archive {name}: {err}"
-                    );
+                    log::warn!("Theater {theater_name}: skipping optional archive {name}: {err}");
                 }
             }
         }
@@ -560,7 +560,8 @@ impl AssetManager {
         Ok(loaded_count)
     }
 
-    /// Check if a file is available through a registered MIX or the loose root.
+    /// Check the registered MIX and startup loose-file catalogs without loading
+    /// payloads. Catalog presence does not guarantee a subsequent disk read.
     /// Retail provenance: MIX-then-raw availability — `CCFileClass__IsAvailable_MixThenRaw` @ `0x00473C50`.
     pub fn contains(&self, name: &str) -> bool {
         self.lookup_location_for_name(name).is_some() || self.loose_asset(name).is_some()
@@ -940,36 +941,12 @@ impl AssetManager {
                 continue;
             }
 
-            let bytes = match entry.metadata() {
-                Ok(metadata) if metadata.len() == 0 => LooseBytes::Empty,
-                Ok(_) => {
-                    let file = match File::open(&path) {
-                        Ok(file) => file,
-                        Err(err) => {
-                            log::debug!("Skipping loose {}: {}", path.display(), err);
-                            continue;
-                        }
-                    };
-                    let mapped = unsafe { memmap2::MmapOptions::new().map(&file) };
-                    match mapped {
-                        Ok(mapped) => LooseBytes::Mapped(mapped),
-                        Err(err) => {
-                            log::debug!("Skipping loose {}: {}", path.display(), err);
-                            continue;
-                        }
-                    }
-                }
-                Err(err) => {
-                    log::debug!("Skipping loose {}: {}", path.display(), err);
-                    continue;
-                }
-            };
             files.insert(
                 key,
                 LooseAsset {
                     path: path.clone(),
                     source_name: format!("loose:{}", path.display()),
-                    bytes,
+                    bytes: OnceLock::new(),
                 },
             );
         }
@@ -980,6 +957,12 @@ impl AssetManager {
     fn loose_asset(&self, name: &str) -> Option<&LooseAsset> {
         let key = loose_lookup_key(name)?;
         self.loose_files.get(&key)
+    }
+
+    /// Unreadable catalogued files must not hide a readable MIX fallback.
+    fn loose_bytes(&self, name: &str) -> Option<(&LooseAsset, &[u8])> {
+        let asset = self.loose_asset(name)?;
+        Some((asset, asset.bytes()?))
     }
 
     fn loose_path(&self, name: &str) -> Option<&Path> {
@@ -1138,6 +1121,70 @@ mod tests {
     fn make_new_format_mix(name: &str, body: &[u8]) -> MixArchive {
         MixArchive::from_bytes(make_new_format_mix_bytes(name, body))
             .expect("new-format test mix should parse")
+    }
+
+    #[test]
+    fn loose_payloads_are_lazy_stable_and_do_not_lock_writable_files() {
+        let dir = TestDirectory::new("mutable-loose");
+        for name in ["SAVE0001.SED", "RandMap.Sed", "RandMap.img", "RandMap.PCX"] {
+            std::fs::write(dir.path().join(name), b"old payload").expect("initial file");
+        }
+        std::fs::write(dir.path().join("empty.bin"), b"").expect("empty file");
+        let manager = empty_manager(dir.path());
+        assert!(manager.contains("RANDMAP.PCX"));
+        assert!(
+            manager
+                .loose_files
+                .values()
+                .all(|file| file.bytes.get().is_none())
+        );
+
+        for name in ["SAVE0001.SED", "RandMap.Sed", "RandMap.img", "RandMap.PCX"] {
+            let path = dir.path().join(name);
+            std::fs::write(&path, b"first lookup").expect("write after catalog creation");
+            let borrowed = manager.get_ref(name).expect("loose payload");
+            assert_eq!(borrowed, b"first lookup");
+            std::fs::write(&path, b"new").expect("truncate while borrowed payload lives");
+            assert_eq!(std::fs::read(&path).expect("current disk bytes"), b"new");
+            assert_eq!(borrowed, b"first lookup", "owned borrow remains stable");
+            assert_eq!(manager.get_ref(name), Some(borrowed));
+        }
+        assert_eq!(manager.get_ref("empty.bin"), Some(&b""[..]));
+    }
+
+    #[test]
+    fn unreadable_loose_snapshot_falls_through_all_byte_apis_to_mix() {
+        let dir = TestDirectory::new("unreadable-loose");
+        let path = dir.path().join("duplicate.shp");
+        std::fs::write(&path, b"loose").expect("initial loose file");
+        let mut manager = empty_manager(dir.path());
+        manager.archives.push(NamedArchive {
+            name: "first.mix".to_string(),
+            archive: make_new_format_mix("duplicate.shp", b"archived"),
+        });
+        manager.rebuild_indexes();
+        std::fs::remove_file(&path).expect("remove before first payload read");
+        assert_eq!(
+            manager.get("duplicate.shp").as_deref(),
+            Some(&b"archived"[..])
+        );
+        assert_eq!(manager.get_ref("duplicate.shp"), Some(&b"archived"[..]));
+        assert_eq!(
+            manager.get_with_source("duplicate.shp"),
+            Some((b"archived".to_vec(), "first.mix".to_string()))
+        );
+        assert_eq!(
+            manager.get_with_source_ref("duplicate.shp"),
+            Some((&b"archived"[..], "first.mix"))
+        );
+        let resolved = manager.resolve_ref("duplicate.shp").expect("MIX fallback");
+        assert_eq!(resolved.bytes, b"archived");
+        assert_eq!(resolved.source_archive, "first.mix");
+        let cached = manager
+            .load_file_from_mix("duplicate.shp")
+            .expect("sticky fallback");
+        assert_eq!(&*cached.bytes, b"archived");
+        assert_eq!(&*cached.source_archive, "first.mix");
     }
 
     #[test]
@@ -1589,7 +1636,7 @@ mod tests {
                 LooseAsset {
                     path: PathBuf::from("RA2MD.CSF"),
                     source_name: "loose:RA2MD.CSF".to_string(),
-                    bytes: LooseBytes::Owned(Box::from(&b"loose"[..])),
+                    bytes: OnceLock::from(Some(Box::from(&b"loose"[..]))),
                 },
             )]),
             active_theater: None,


### PR DESCRIPTION
Skirmish Start and Options close could not overwrite RA2MD.INI on Windows because the process asset manager retained a mapping of every loose file. Replace eager loose-file mappings with lazy owned snapshots, allowing profile, saved-seed and generated-preview writers to replace existing files while borrowed asset bytes stay stable. Keep MIX storage, loose precedence, unreadable-loose fallback and the process-sticky CRC cache.

The filename catalog and first-read snapshots remain bounded Rust storage policy; this does not claim native live-file caching equivalence. Original Options write instructions and active callers establish the physical write lifecycle. Independently confirmed Ghidra comments were saved and read back.

Validation: 8,698 library tests passed, 121 ignored; Clippy completed with 1,150 repository warnings. Windows production checks covered alternating Skirmish, in-game Options and launcher writes, preservation of unrelated INI content, restart persistence, overwrite and reload of an existing seed, and repeated replacement of RandMap.Sed/RandMap.img. No persistence error 1224 occurred in the validation interval. Fresh independent read-only criticism passed evidence, design, final diff and validation.

Launcher and Game Controls rendering gaps remain documented for subsequent shell work.
