### PR TITLE
Render launcher Options with retail controls

### DIFF
--- a/docs/research/skirmish-ui/2026-09-12-launcher-options-shell.md
+++ b/docs/research/skirmish-ui/2026-09-12-launcher-options-shell.md
@@ -1,0 +1,202 @@
+# Launcher Options: retail layout and shared text admission
+
+Status: final validation and independent scoped review passed. This increment covers
+the launcher D5 parent, not the unfinished Keyboard/Network children or whole
+shell-family acceptance.
+
+The former egui card requested 720 logical points on an 800-pixel shell and
+constrained its horizontal parent to 540 points. At 125% desktop DPI, the right
+column collapsed and settings were clipped. The new production path uses the
+retail physical rectangles, bitmap font and shell/control artwork. The retained
+`OptionsDialogState` still owns values and ordered events; both the physical
+view and assetless fallback drain the same app transaction for previews,
+resolution changes, accepted settings and parent results.
+
+## Acceptance for this increment
+
+- At 800x600, all four sections, captions, values, title, warning and three
+  right-column buttons fit the production frame at the available desktop DPI.
+- Six sliders reach each endpoint. Thumb capture follows movement outside the
+  control; a rail click changes once. Disabled audio rejects edits.
+- Only checkbox icons toggle. Resolution opening, scrolling, selection and
+  dismissal remain topmost, with ordered open/close cues and immediate selected
+  dimensions. Main Menu persists settings. Keyboard/Network currently return
+  fresh snapshots through their existing placeholder routes; their child screens
+  remain required follow-up work.
+- Shared text keeps the first partially clipped line and admits subsequent
+  lines by consumed cell advance. Normal and animated text use the same rule.
+  Inspect affected Skirmish and in-game text as well as launcher output.
+- Independent original-evidence/diff/validation criticism passes before
+  publication. A plausible Rust frame is not a native pixel comparison.
+
+## Original evidence
+
+Binary: retail `gamemd.exe`, x86, image base400000, SHA256
+`1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c`.
+
+Owner55FC80 supplies dialogD5 and procedure55FDB0 to622650 at55FCB3–55FCC1.
+The original RT_DIALOG/D5/language1033 resource is an extended533x369 DLU
+template,31 controls, MS Sans Serif8. DLU conversion uses base6x13. The resource
+was independently extracted directly from PE bytes and consumed all2018 bytes.
+Hidden/disabled603 is excluded. Static captions and slider values are separate
+controls, rather than combined labels.
+
+| Control | Physical rectangle at800x600 |
+| --- | --- |
+| Detail52B | 134,86,180,21 |
+| Difficulty50F | 138,208,180,21 |
+| Scroll52A | 357,330,180,21 |
+| Music52F / Sound532 / Voice536 | 123 /269 /416,470,128,21 |
+| Resolution6ED face | 351,86,180,24 |
+| Keyboard5CE / Network5CD | 644,199 /241,156,42 |
+| Main Menu686 | 644,535,156,42 |
+| Title694 | 635,9,162,17 |
+| Warning71C | 670,47,92,54 |
+
+608CD0/609730 perform ordinary right-column anchoring;60B950 applies title
+y+7 and height+1. These are source-derived dimensions, not captured native HWND
+rectangles. 603 is hidden and disabled in the resource. 6153E0 selects GAME.FNT
+and yellow foreground; ordinary statics keep resource horizontal alignment and
+top alignment. Checkbox6163A0 paints an18x18 icon, admits icon-local mouse down,
+and starts vertically centered caption text at x+26.
+
+60CF00's default background path selects MNSCRNL.SHP through SHELL.PAL. D5
+is excluded from60CAF0's SDTP frame-1 highlight allowlist. Warning6038F7→6039EF
+resolves original pointer833674→833688 to SDWRNANM.SHP, using SHELL2.PAL:
+92x53 canvas,91 frames. 60A9C8–60AA0B initializes frame0 and a1ms startup timer;
+6153E0's timer path then requests a recurring interval equal to the frame count.
+Paint advances the frame; elapsed time alone does not select it. The Rust
+presentation retains dirty content and acknowledges it after successful present.
+Title reuses the shared30ms kind-1 reveal with step1 and leading span8.
+
+Trackbar61D950 distinguishes two formulas. 61DA52–61DA79 establishes the usable
+span `width - plaque_reserve - 13`. Initial setup,405 and406 project position
+to thumb offset using `span * position / range`; drag/click quantize mouse using
+`range + 1`, then project using `range`. The previous launcher thumb helper used
+`range + 1` for both and stopped short. 4AC disables the plaque for the first
+three sliders;4AE suppresses change sound for the audio sliders without changing
+their default50-pixel plaque. Neither message resizes the control.
+
+[The reproducible original-instruction oracle](../../../tools/storage_oracle/launcher_trackbar.py)
+checks16 supplied geometry combinations,92 positions,2736 captured-drag pointer
+samples and2464 admitted rail-click comparisons. Generation and default read-only
+regeneration passed. Supplied width/reserve cross combinations are arithmetic
+coverage, not a claim that every combination appears in D5.
+
+Resolution617250 paints a24px face and sets GAME.FNT row height17+6=23.
+6180CF–618205 sizes custom ComboDropWin from dropped-control allocation and
+whole rows. The nominal120px allocation admits five rows; exact Win32
+CB_GETDROPPEDCONTROLRECT border adjustments remain unmeasured. 60D540 selects
+on mouse down, initializes top index0, and60E4E9–60E500 plays GUIComboCloseSound
+before selection or outside dismissal. Scrollbar forwarding precedes that cue.
+
+The shared line-admission discrepancy is independently established through
+6153E0→775690/621040→433CA0/434CD0: the original HWND rectangle is the clip;
+backing-surface +1 dimensions do not enlarge it. 434CD0 draws the first line
+before a height test. At newline/wrap tails434EC2–434ED7 and435112–435127,
+consumed cell advance stops further lines at the nonzero height limit. The old
+Rust precheck discarded a line when its glyph did not fit completely. Both
+plain and Path-A wrappers now admit the line and preserve the original scissor.
+Retail GAME.FNT has17px cell advance and16 bitmap rows: an ordinary unwrapped,
+top-aligned16px static already passed the old check. This correction concerns
+partial lines and smaller clips; it is not evidence for the cause of every
+previously missing label.
+
+[The full-body line-submission oracle](../../../tools/storage_oracle/shell_text_lines.py)
+executes434CD0 with original glyph lookup and supplied font metrics. Sixty-six
+cases include48 newline/wrap cases covering one through four lines and
+heights0/1/16/17/18/34, plus six saved-space word-suffix cases at widths18/24/30
+and heights0/34, and12 no-space cases with two/three/four/six glyphs at
+widths6/12/18 and unlimited height.
+Only surface setup/teardown and glyph raster are substituted. Generation and
+read-only comparison passed; Rust compares the emitted positions in both text
+paths. This demonstrates bounded line admission, not native raster pixels.
+
+The executable comparison exposed a pre-existing shared wrapping bug:
+`A A` at width6 could produce a reversed byte span, and overflow after part of
+a word could skip measuring that prefix on the next line. Original434F60–434F64
+rewinds the scanner to the saved space;4350F5–435103 and43512D–435138 resume
+after it. `BitFont::wrap_layout` now retains the break's character index and
+width together and restarts after that break, deriving UTF-8 bounds from the
+same index. The six additional native cases require those instructions to run.
+Both shell text paths compare all66 native submission sequences. The former
+vertical-centering test expected a fully fitting glyph; native line admission
+instead submits both lines at y=-2/15 in a30px rect and leaves clipping intact.
+
+The subsequent word-suffix comparison exposed a distinct hard-cut mismatch.
+Original434F6F–434F78 moves the emission boundary back by one UTF-16 unit;
+43512D–435138 resumes measurement at the overflowing unit. The deferred fitting
+glyph stays in the next emitted span without being measured again. Rust now
+keeps those two positions distinct. The bounded no-space fixtures show that
+native can emit an empty first line at minimum width, or submit later glyphs
+beyond the supplied width; clipping is a separate responsibility. This is not
+a conventional word-wrapper substitution or a general Unicode equivalence claim.
+
+612B70 type1 buttons keep the normal foreground when pressed. The shared
+button text rectangle matches61358D–6135CD: unpressed top+1/right-2; pressed
+left+2/top+5. Frames2 and4 represent idle and pressed. Frame3 is driven by a
+separate timer flag, not ordinary pointer hover. No D5 primary-procedure sender
+of that timer's4DC message was found; this increment keeps the ordinary2/4 path.
+
+Fresh criticism found a lost-focus gesture issue. The host now cancels slider,
+button and popup-drag capture at focus loss before accepting subsequent movement,
+matching61E3AF–61E44E's absent-MK_LBUTTON cancellation requirement. A regression
+checks reentry movement cannot change packed settings or emit preview events.
+
+## Validation and remaining limits
+
+The initial full suite reported8706 passed, two failed and121 ignored. The
+failures were the wrapping defect and superseded vertical-centering expectation
+described above. The next run passed8707 with one hard-cut mismatch and121
+ignored; that source repair and expanded comparison are described above. The
+final candidate full `cargo test -p vera20k --lib` passed8708 tests with zero
+failures and121 ignored in30.58s (`launcher-options-full-tests-final2.log`).
+`cargo clippy -p vera20k --lib` exited0 in1m22s with1152 warnings, including
+existing warnings and nonblocking style suggestions (`launcher-options-clippy.log`).
+The release build passed in4m39s with91 warnings. Fresh independent read-only
+criticism of native evidence, design, final diff, documentation and validation
+passed after the documented repairs. The approval covers this bounded increment.
+
+Production release215ad210c994cd778741b244cf0ac9f5b18ee28be4e19750acb4df71180473e2
+was inspected at125% desktop scale (800x600 physical client). All four sections,
+six sliders, three checkboxes, title/warning and three buttons fit. Mouse drags
+and rail clicks reached both endpoints of every slider; all three checkbox icons
+toggled. The resolution popup showed this runtime's three available modes and
+selected800x600 without resizing the shell. Keyboard and Network route through
+their existing stubs and reconstruct the parent with saved values. Main Menu
+exit/reentry also retained the settings; direct RA2MD.INI readback confirmed
+resolution800x600, detail2, difficulty2, scroll0, three audio volumes1.0, tooltips
+off, target lines off and hidden objects on. This release precedes the subsequent
+word-wrap repair; final release validation follows below.
+
+Local evidence is retained under `.local/seed-browser-runtime/`:
+`launcher-options-native-initial.png`, `launcher-options-resolution-popup.png`,
+`launcher-options-endpoints.png`, `launcher-options-reopened.png`, and
+`RA2MD-launcher-endpoints.INI`. Captures establish VERA output, not retail pixel
+equivalence or warning-animation cadence.
+
+Final release SHA-256
+`595932ce9a66adc14abc80727343f893949df8e62ca5c7213a757c0b82695724`
+was inspected after process restart. All sections and persisted settings remained
+visible and correct. Resolution popup opening and outside dismissal passed;
+clicking the Main Menu button while the popup was open only dismissed the popup,
+and the next click returned to the main menu. Final captures are
+`launcher-options-final-restart.png` and `launcher-options-final-popup.png`.
+The final executable's production Skirmish capture passed its diagnostic
+validator and retained the exact previous frame SHA-256
+`fe7d42bfebaca25a608e1be3485a2f2f576beca75867ae4961a73a546c42f8fa`.
+The local bundle is `.local/launcher-options-skirmish-capture`; this is a Rust
+visual nonregression check, not native pixel equivalence.
+
+Neighbor checks on the earlier `215ad210...` release reached Skirmish, loading, the first800x600
+tactical frame, Game Controls, its Escape return and Abort to the main menu.
+Game Controls still lacks its panel and several captions, and the pause/abort
+menus still use egui; those ordinary family gaps remain open. Captures
+`launcher-neighbor-skirmish.png` and `launcher-neighbor-game-controls-gap.png`
+record the observed scope without attributing all missing labels to clipping.
+
+Independently confirmed Ghidra plate comments at61D950,434CD0 and55FC80 were
+written, the intended `gamemd.exe` program saved, and all three comments read
+back exactly. Existing function names were preserved.
+Native pixel comparison, complete D5 entry/exit transition equivalence, and all
+child-shell behavior remain open. This report does not certify those mechanisms.

--- a/src/app/frame.rs
+++ b/src/app/frame.rs
@@ -196,6 +196,7 @@ impl App {
                 });
         let mut pending_main_menu_entry_token = None;
         let mut pending_main_menu_title_receipt = None;
+        let mut pending_launcher_title_receipt = None;
         use crate::app::diagnostics::shell_capture::PresentedShell;
         let mut presented_shell = PresentedShell::Other;
 
@@ -220,6 +221,11 @@ impl App {
                     &output.texture,
                 )? {
                     pending_main_menu_entry_token = main_menu_entry_token;
+                } else if Self::native_launcher_options_active(state) {
+                    pending_launcher_title_receipt = Some(
+                        crate::app::frontend::skirmish_shell_render::render_launcher_options(
+                            state, &mut encoder, &output.texture,
+                        )?);
                 } else if Self::native_skirmish_shell_active(state) {
                     crate::app::frontend::skirmish_shell_render::render_skirmish_shell(
                         state,
@@ -592,6 +598,10 @@ impl App {
                     .record_presented(receipt),
                 "main-menu title receipt was stale at present commit"
             );
+        }
+        if let Some(receipt) = pending_launcher_title_receipt {
+            anyhow::ensure!(state.frontend.launcher_options_presentation.record_presented(receipt),
+                "launcher title receipt was stale at present commit");
         }
         if let Some(session) = shell_capture.as_deref_mut() {
             session.after_present(state, presented_shell)?;

--- a/src/app/frontend/skirmish_shell_render.rs
+++ b/src/app/frontend/skirmish_shell_render.rs
@@ -17,6 +17,8 @@ use draw_order::{
     validation_modal_semantic_draw_order,
 };
 mod in_game_options;
+mod launcher_options;
+pub(crate) use launcher_options::{LauncherOptionsPresentation, render_launcher_options};
 mod modals;
 mod preview;
 mod text;

--- a/src/app/frontend/skirmish_shell_render/controls.rs
+++ b/src/app/frontend/skirmish_shell_render/controls.rs
@@ -49,6 +49,7 @@ pub(super) fn combo_face_entry(
     rect: RectPx,
 ) -> Option<SkirmishShellChromeEntry> {
     match rect.w {
+        180 => chrome.combo_face_180,
         150 => chrome.combo_face_150,
         117 => chrome.combo_face_117,
         44 => chrome.combo_face_44,
@@ -252,6 +253,11 @@ pub(super) enum ControlPaint {
         rect: RectPx,
         thumb_px: i32,
     },
+    /// D5 Detail/Difficulty/Scroll receive 4AC(false): no numeric plaque.
+    PlainTrackbar {
+        rect: RectPx,
+        thumb_px: i32,
+    },
     Combo {
         rect: RectPx,
         swatch: Option<[f32; 3]>,
@@ -294,16 +300,24 @@ pub(super) fn paint_control(
                 push_entry(out, entry, checkbox_icon_rect(rect), SHELL_CONTROL_DEPTH);
             }
         }
-        ControlPaint::Trackbar { rect, thumb_px } => {
+        ControlPaint::Trackbar { rect, thumb_px }
+        | ControlPaint::PlainTrackbar { rect, thumb_px } => {
             // The active owner-draw callback blits plaque and thumb art before
             // drawing its two adjacent border-2 primitive frames. The frame
             // entry includes the native two-pixel outside expansion.
-            paint_trackbar_plaque(out, chrome, rect, SHELL_CONTROL_DEPTH);
+            let plain = matches!(paint, ControlPaint::PlainTrackbar { .. });
+            if !plain {
+                paint_trackbar_plaque(out, chrome, rect, SHELL_CONTROL_DEPTH);
+            }
             if let Some(thumb) = chrome.trackbar_thumb_trakgrip {
                 let thumb_rect = trackbar_thumb_rect(rect, thumb_px);
                 push_entry(out, thumb, thumb_rect, SHELL_CONTROL_DEPTH - 0.00002);
             }
-            if let Some(frame) = chrome.trackbar_rail {
+            if let Some(frame) = if plain {
+                chrome.trackbar_plain_180
+            } else {
+                chrome.trackbar_rail
+            } {
                 push_entry_native(
                     out,
                     frame,

--- a/src/app/frontend/skirmish_shell_render/launcher_options.rs
+++ b/src/app/frontend/skirmish_shell_render/launcher_options.rs
@@ -1,0 +1,483 @@
+//! Retail launcher Options (D5): physical shell paint over the retained model.
+//! Active owner55FC80, resourceD5, common static6153E0 and trackbar61D950.
+
+use super::{chrome::*, controls::*, *};
+use crate::app::AppState;
+use crate::render::batch::SpriteInstance;
+use crate::render::shell_text::{self, ShellAlign, ShellTextDraw, TextRect};
+use crate::render::shell_text_reveal::PathAReveal;
+use crate::ui::main_menu_dialogs::options::shell::{LauncherLabelAlign, LauncherOptionsLayout};
+use crate::ui::main_menu_dialogs::options::{LauncherTrackbarId, OptionsDialogState};
+use crate::ui::shell::geom::RectPx;
+use crate::ui::shell::static_reveal::{Kind1PaintWindow, Kind1RevealReceipt, Kind1StaticReveal};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+pub(crate) struct LauncherOptionsPresentation {
+    pub(crate) title: Kind1StaticReveal,
+    warning: WarningAnimation,
+}
+
+/// Static71C has a one-millisecond startup gate, then a timer interval equal
+/// to the SHP frame count (91), not a continuously advancing 1ms animation.
+/// 60A9C8..60AA0B initializes;6153E0 WM_TIMER invalidates and WM_PAINT advances.
+#[derive(Default)]
+struct WarningAnimation {
+    started: Option<Instant>,
+    next_timer: Option<Instant>,
+    displayed: Option<usize>,
+    next_frame: usize,
+    dirty: bool,
+}
+
+impl WarningAnimation {
+    fn prepare(&mut self, now: Instant, frames: usize) -> (Option<usize>, bool) {
+        if frames == 0 {
+            return (None, false);
+        }
+        let started = *self.started.get_or_insert(now);
+        if now.saturating_duration_since(started) <= Duration::from_millis(1) {
+            return (None, false);
+        }
+        if self.next_timer.is_none_or(|deadline| now >= deadline) {
+            self.next_timer = Some(now + Duration::from_millis(frames as u64));
+            self.dirty = true;
+        }
+        if self.dirty {
+            (Some(self.next_frame % frames), true)
+        } else {
+            (self.displayed, false)
+        }
+    }
+
+    fn presented(&mut self, frame: usize) {
+        self.displayed = Some(frame);
+        self.next_frame = frame + 1;
+        self.dirty = false;
+    }
+}
+
+pub(crate) struct LauncherPaintReceipt {
+    title: Option<Kind1RevealReceipt>,
+    warning: Option<usize>,
+}
+
+impl LauncherOptionsPresentation {
+    pub(crate) fn record_presented(&mut self, receipt: LauncherPaintReceipt) -> bool {
+        if receipt
+            .title
+            .is_some_and(|r| !self.title.record_presented(r))
+        {
+            return false;
+        }
+        if let Some(frame) = receipt.warning {
+            self.warning.presented(frame);
+        }
+        true
+    }
+}
+
+fn text_draw(
+    font: &BitFont,
+    text: &str,
+    rect: RectPx,
+    align: ShellAlign,
+    rgb: [f32; 3],
+) -> ShellTextDraw {
+    shell_text::draw_in_rect(
+        font,
+        text,
+        TextRect {
+            x: rect.x,
+            y: rect.y,
+            w: rect.w.max(0) as u32,
+            h: rect.h.max(0) as u32,
+        },
+        rgb,
+        align,
+        [0.0, 0.0],
+        SHELL_CONTROL_TEXT_DEPTH,
+        None,
+    )
+}
+
+fn build_controls(
+    atlas: &SkirmishShellChromeAtlas,
+    layout: &LauncherOptionsLayout,
+    dialog: &OptionsDialogState,
+) -> Vec<SpriteInstance> {
+    let mut out = Vec::new();
+    let chrome = atlas.control_chrome();
+    for (id, rect) in layout.trackbars {
+        let thumb_px = dialog.shell_trackbar_thumb_left(id, rect.w) - 1;
+        let plain = matches!(
+            id,
+            LauncherTrackbarId::Detail
+                | LauncherTrackbarId::Difficulty
+                | LauncherTrackbarId::Scroll
+        );
+        paint_control(
+            &mut out,
+            &chrome,
+            if plain {
+                ControlPaint::PlainTrackbar { rect, thumb_px }
+            } else {
+                ControlPaint::Trackbar { rect, thumb_px }
+            },
+        );
+    }
+    for (id, rect) in layout.checkboxes {
+        paint_control(
+            &mut out,
+            &chrome,
+            ControlPaint::Checkbox {
+                rect,
+                checked: dialog.shell_checkbox_checked(id),
+            },
+        );
+    }
+    paint_control(
+        &mut out,
+        &chrome,
+        ControlPaint::Combo {
+            rect: layout.resolution,
+            swatch: None,
+            open: dialog.shell_popup(layout).is_some(),
+            disabled: false,
+        },
+    );
+    for (id, rect) in layout.buttons {
+        push_right_panel_button_shp(
+            &mut out,
+            atlas,
+            rect,
+            dialog.shell_button_pressed(id),
+            false,
+            SHELL_CONTROL_DEPTH,
+        );
+    }
+    out
+}
+
+fn build_text(
+    font: &BitFont,
+    layout: &LauncherOptionsLayout,
+    dialog: &OptionsDialogState,
+    title: Option<crate::ui::shell::static_reveal::Kind1RevealWindow>,
+) -> Vec<ShellTextDraw> {
+    let mut out = Vec::new();
+    for label in dialog.shell_labels(layout) {
+        let align = match label.align {
+            LauncherLabelAlign::Left => ShellAlign::NONE,
+            LauncherLabelAlign::Center => ShellAlign::H_CENTER,
+            LauncherLabelAlign::Right => ShellAlign::H_RIGHT,
+        };
+        if label.title {
+            if let Some(window) = title {
+                out.push(shell_text::draw_in_rect_path_a(
+                    font,
+                    label.text,
+                    TextRect {
+                        x: label.rect.x,
+                        y: label.rect.y,
+                        w: label.rect.w as u32,
+                        h: label.rect.h as u32,
+                    },
+                    align,
+                    [0.0, 0.0],
+                    SHELL_CONTROL_TEXT_DEPTH,
+                    PathAReveal {
+                        count: window.count,
+                        range: window.range,
+                        base_rgb: [255, 255, 0],
+                        highlight_rgb: [255, 255, 255],
+                    },
+                ));
+            }
+        } else {
+            out.push(text_draw(
+                font,
+                label.text,
+                label.rect,
+                align,
+                SHELL_LABEL_TEXT_RGB,
+            ));
+        }
+    }
+    for (id, rect) in layout.checkboxes {
+        out.push(text_draw(
+            font,
+            dialog.shell_checkbox_label(id),
+            RectPx::new(rect.x + 26, rect.y, rect.w - 26, rect.h),
+            ShellAlign::V_CENTER,
+            SHELL_LABEL_TEXT_RGB,
+        ));
+    }
+    for (id, rect) in layout.trackbars {
+        if matches!(
+            id,
+            LauncherTrackbarId::Score | LauncherTrackbarId::Sound | LauncherTrackbarId::Voice
+        ) {
+            out.push(text_draw(
+                font,
+                &dialog.trackbar_position(id).to_string(),
+                crate::ui::skirmish_shell::trackbar_value_text_rect(rect),
+                ShellAlign::H_CENTER | ShellAlign::V_CENTER,
+                if dialog.launcher_audio_available() {
+                    SHELL_LABEL_TEXT_RGB
+                } else {
+                    SHELL_DISABLED_TEXT_RGB_FROM_PACKED_0000009F
+                },
+            ));
+        }
+    }
+    out.push(text_draw(
+        font,
+        dialog.shell_selected_resolution_text(),
+        RectPx::new(
+            layout.resolution.x + 3,
+            layout.resolution.y,
+            layout.resolution.w - 23,
+            layout.resolution.h,
+        ),
+        ShellAlign::V_CENTER,
+        SHELL_LABEL_TEXT_RGB,
+    ));
+    for (id, rect) in layout.buttons {
+        let pressed = dialog.shell_button_pressed(id);
+        // 612B70 type1: ordinary press retains AC18A4 foreground; the text
+        // rectangle changes at61358D..6135CD, independently of SHP geometry.
+        let native_text = button_text_rect(rect, pressed);
+        out.push(text_draw(
+            font,
+            dialog.shell_button_label(id),
+            RectPx::new(
+                native_text.x,
+                native_text.y,
+                native_text.w as i32,
+                native_text.h as i32,
+            ),
+            ShellAlign::H_CENTER | ShellAlign::V_CENTER,
+            button_label_color(),
+        ));
+    }
+    out
+}
+
+pub(crate) fn render_launcher_options(
+    state: &mut AppState,
+    encoder: &mut wgpu::CommandEncoder,
+    destination: &wgpu::Texture,
+) -> anyhow::Result<LauncherPaintReceipt> {
+    let now = Instant::now();
+    let dialog = state
+        .frontend
+        .options_dialog
+        .as_ref()
+        .expect("launcher active");
+    let presentation = &mut state.frontend.launcher_options_presentation;
+    presentation.title.start(dialog.shell_title_text(), now);
+    presentation.title.poll_timer(now);
+    let (title, title_receipt) = match presentation.title.paint_window() {
+        Kind1PaintWindow::Hidden => (None, None),
+        Kind1PaintWindow::Retained(window) => (Some(window), None),
+        Kind1PaintWindow::Due { window, receipt } => (Some(window), Some(receipt)),
+    };
+    let atlas = state
+        .frontend
+        .skirmish_shell_chrome
+        .as_ref()
+        .expect("launcher atlas");
+    let (warning, warning_dirty) = presentation
+        .warning
+        .prepare(now, atlas.launcher_warning_frames.len());
+    let layout =
+        LauncherOptionsLayout::new(state.render_width() as i32, state.render_height() as i32);
+    // Existing common-shell geometry is shared with Skirmish; only the parent
+    // art binding differs (60CF00's generic MNSCRNL/SHELL.PAL path).
+    let common = compute_layout(state.render_width(), state.render_height());
+    let mut instances = Vec::new();
+    if let Some(bg) = atlas.generic_background_large_mnscrnl_shell {
+        push_entry_native(&mut instances, bg, 0, 0, SHELL_PARENT_BACKGROUND_DEPTH);
+    }
+    push_right_panel_base_instances(&mut instances, atlas, &common, 0, false);
+    push_lower_strip_instance(&mut instances, atlas, &common);
+    if let Some(frame) = warning.and_then(|i| atlas.launcher_warning_frames.get(i)) {
+        push_flag_entry_native_clipped_centered(
+            &mut instances,
+            *frame,
+            layout.warning,
+            SHELL_CONTROL_DEPTH,
+        );
+    }
+    instances.extend(build_controls(atlas, &layout, dialog));
+    let texts = build_text(&state.renderer.bit_font, &layout, dialog, title);
+    let mut popup_instances = Vec::new();
+    let mut popup_text = Vec::new();
+    if let Some(popup) = dialog.shell_popup(&layout) {
+        push_solid_rect_px(
+            &mut popup_instances,
+            atlas.white_pixel,
+            popup.rect,
+            SHELL_DROPDOWN_BG_RGB_PENDING_COMBODROPWIN_SOURCE_CAPTURE,
+            SHELL_DROPDOWN_DEPTH,
+        );
+        for (i, row) in dialog
+            .shell_resolution_rows()
+            .iter()
+            .enumerate()
+            .skip(popup.first_row)
+            .take(popup.visible_rows)
+        {
+            let rect = RectPx::new(
+                popup.content.x,
+                popup.content.y + (i - popup.first_row) as i32 * popup.row_height,
+                popup.content.w,
+                popup.row_height,
+            );
+            if popup.hovered.or(popup.selected) == Some(i) {
+                push_solid_rect_px(
+                    &mut popup_instances,
+                    atlas.white_pixel,
+                    rect,
+                    OWNERDRAW_SELECTED_RGB_FROM_DAT_00AC4604_PACKED_000000FF,
+                    SHELL_DROPDOWN_DEPTH,
+                );
+            }
+            popup_text.push(text_draw(
+                &state.renderer.bit_font,
+                &row.label,
+                RectPx::new(rect.x + 3, rect.y, rect.w - 6, rect.h),
+                ShellAlign::V_CENTER,
+                SHELL_LABEL_TEXT_RGB,
+            ));
+        }
+        if let (Some(scrollbar), Some(thumb)) = (popup.scrollbar, popup.thumb) {
+            paint_control(
+                &mut popup_instances,
+                &atlas.control_chrome(),
+                ControlPaint::ScrollBar {
+                    scrollbar,
+                    thumb,
+                    pressed_part: None,
+                },
+            );
+        }
+        push_ownerdraw_two_pixel_bevel_frame_px(
+            &mut popup_instances,
+            atlas.white_pixel,
+            popup.rect,
+            SHELL_DROPDOWN_DEPTH,
+        );
+    }
+    state.renderer.batch_renderer.update_camera(
+        &state.renderer.gpu,
+        state.render_width() as f32,
+        state.render_height() as f32,
+        0.0,
+        0.0,
+        1.0,
+        crate::render::batch::DepthAxis::NONE,
+    );
+    let batch = &state.renderer.batch_renderer;
+    let gpu = &state.renderer.gpu;
+    let chrome_buffer = batch.create_instance_buffer(gpu, &instances);
+    let text_buffers: Vec<_> = texts
+        .iter()
+        .map(|d| batch.create_instance_buffer(gpu, &d.instances))
+        .collect();
+    let popup_buffer = batch.create_instance_buffer(gpu, &popup_instances);
+    let popup_text_buffers: Vec<_> = popup_text
+        .iter()
+        .map(|d| batch.create_instance_buffer(gpu, &d.instances))
+        .collect();
+    let cursor: Vec<_> = shell_cursor_instance(state).into_iter().collect();
+    let cursor_buffer = batch.create_instance_buffer(gpu, &cursor);
+    let cursor_texture = state
+        .match_state
+        .match_presentation
+        .software_cursor
+        .as_ref()
+        .and_then(|c| c.get(crate::app::types::CursorId::Default))
+        .and_then(|s| s.frames.first())
+        .map(|f| &f.texture);
+    let color = state.renderer.shell_surface_presenter.source_render_view();
+    let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("Launcher Options D5"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: &color,
+            depth_slice: None,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(crate::app::types::CLEAR_COLOR),
+                store: wgpu::StoreOp::Store,
+            },
+        })],
+        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+            view: &state.renderer.depth_view,
+            depth_ops: Some(wgpu::Operations {
+                load: wgpu::LoadOp::Clear(1.0),
+                store: wgpu::StoreOp::Store,
+            }),
+            stencil_ops: None,
+        }),
+        timestamp_writes: None,
+        occlusion_query_set: None,
+    });
+    if let Some((buffer, count)) = &chrome_buffer {
+        batch.draw_with_buffer_passthrough(&mut pass, &atlas.texture, buffer, *count);
+    }
+    for (draw, buffer) in texts.iter().zip(&text_buffers) {
+        if let Some((buffer, count)) = buffer {
+            if draw.scissor.w == 0 || draw.scissor.h == 0 {
+                continue;
+            }
+            pass.set_scissor_rect(
+                draw.scissor.x,
+                draw.scissor.y,
+                draw.scissor.w,
+                draw.scissor.h,
+            );
+            batch.draw_with_buffer_passthrough(
+                &mut pass,
+                state.renderer.bit_font.atlas(),
+                buffer,
+                *count,
+            );
+        }
+    }
+    pass.set_scissor_rect(0, 0, state.render_width(), state.render_height());
+    if let Some((buffer, count)) = &popup_buffer {
+        batch.draw_with_buffer_passthrough(&mut pass, &atlas.texture, buffer, *count);
+    }
+    for (draw, buffer) in popup_text.iter().zip(&popup_text_buffers) {
+        if let Some((buffer, count)) = buffer {
+            pass.set_scissor_rect(
+                draw.scissor.x,
+                draw.scissor.y,
+                draw.scissor.w,
+                draw.scissor.h,
+            );
+            batch.draw_with_buffer_passthrough(
+                &mut pass,
+                state.renderer.bit_font.atlas(),
+                buffer,
+                *count,
+            );
+        }
+    }
+    pass.set_scissor_rect(0, 0, state.render_width(), state.render_height());
+    if let (Some((buffer, count)), Some(texture)) = (&cursor_buffer, cursor_texture) {
+        batch.draw_with_buffer_passthrough(&mut pass, texture, buffer, *count);
+    }
+    drop(pass);
+    state
+        .renderer
+        .shell_surface_presenter
+        .encode_present(encoder, destination);
+    state.platform.window.request_redraw();
+    Ok(LauncherPaintReceipt {
+        title: title_receipt,
+        warning: warning.filter(|_| warning_dirty),
+    })
+}

--- a/src/app/frontend/state.rs
+++ b/src/app/frontend/state.rs
@@ -66,6 +66,7 @@ pub(crate) struct FrontendState {
     pub(crate) exit_confirm_modal: Option<crate::ui::main_menu_dialogs::ExitConfirmModalState>,
     /// Retained active-YR launcher Options `0xD5` parent snapshot.
     pub(crate) options_dialog: Option<crate::ui::main_menu_dialogs::OptionsDialogState>,
+    pub(crate) launcher_options_presentation: super::skirmish_shell_render::LauncherOptionsPresentation,
     /// Movies & Credits sub-panel (open-level shell; playback not implemented).
     pub(crate) movies_credits_dialog:
         Option<crate::ui::main_menu_dialogs::MoviesCreditsDialogState>,

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -499,6 +499,9 @@ impl ApplicationHandler for App {
                     state.match_state.input.tactical_mouse = Default::default();
                     state.match_state.input.selection_state.cancel_drag();
                     state.match_state.input.minimap_dragging = false;
+                    if let Some(dialog) = state.frontend.options_dialog.as_mut() {
+                        dialog.shell_cancel_pointer_gesture();
+                    }
                 }
                 Self::set_window_active(state, active);
             }
@@ -703,6 +706,10 @@ impl ApplicationHandler for App {
                 if crate::app::frontend::shell_transition::blocks_shell_input(state) {
                     return;
                 }
+                if Self::native_launcher_options_active(state) {
+                    Self::handle_launcher_options_mouse(state, None);
+                    return;
+                }
                 if !egui_consumed
                     && (state.frontend.screen == GameScreen::InGame || state.frontend.screen == GameScreen::SpawnPick)
                 {
@@ -751,6 +758,10 @@ impl ApplicationHandler for App {
                 // path; the egui fallback and the other egui dialogs (options/movies/
                 // campaign) were already handled by egui above.
                 if Self::main_menu_dialog_open(state) {
+                    if Self::native_launcher_options_active(state) && button == MouseButton::Left {
+                        Self::handle_launcher_options_mouse(state, Some(btn_state.is_pressed()));
+                        return;
+                    }
                     if state.frontend.exit_confirm_modal.is_some()
                         && state.frontend.screen == GameScreen::MainMenu
                         && !state.frontend.main_menu_shell_failed

--- a/src/app/initialize.rs
+++ b/src/app/initialize.rs
@@ -654,6 +654,7 @@ impl App {
                 startup_splash,
                 exit_confirm_modal: None,
                 options_dialog: None,
+                launcher_options_presentation: Default::default(),
                 movies_credits_dialog: None,
                 campaign_select: None,
                 score_screen: None,

--- a/src/app/shell_main_menu.rs
+++ b/src/app/shell_main_menu.rs
@@ -551,6 +551,8 @@ impl App {
     /// profile, current-monitor dimension pairs, live CSF table, and frozen
     /// process-start common audio gate. No display mode is applied here.
     fn open_launcher_options_dialog(state: &mut AppState) {
+        Self::ensure_skirmish_shell_chrome(state);
+        state.frontend.launcher_options_presentation = Default::default();
         use crate::app::persistence::options::launcher::launcher_dialog_from_profile;
         use crate::ui::main_menu_dialogs::options::LauncherOptionsLabels;
 
@@ -596,6 +598,7 @@ impl App {
             LauncherCue::GenericClick => rules.general.generic_click_sound.as_deref(),
             LauncherCue::Checkbox => rules.general.gui_checkbox_sound.as_deref(),
             LauncherCue::ComboOpen => rules.general.gui_combo_open_sound.as_deref(),
+            LauncherCue::ComboClose => rules.general.gui_combo_close_sound.as_deref(),
         });
         let sound_id = sound_id.map(str::to_owned);
         Self::play_shell_ui_sound_by_id(state, sound_id.as_deref());
@@ -622,6 +625,51 @@ impl App {
             assets,
             &state.audio.audio_indices,
         );
+    }
+
+    pub(crate) fn native_launcher_options_active(state: &AppState) -> bool {
+        state.frontend.screen == GameScreen::MainMenu
+            && state.frontend.options_dialog.is_some()
+            && state.frontend.skirmish_shell_chrome.is_some()
+    }
+
+    /// Both physical shell input and the assetless fallback drain the same
+    /// semantic transaction; profile and audio authority remain in their owners.
+    fn dispatch_launcher_options_output(
+        state: &mut AppState,
+        dialog: crate::ui::main_menu_dialogs::OptionsDialogState,
+        output: crate::ui::main_menu_dialogs::options::LauncherOptionsFrameOutput,
+    ) {
+        {
+            let mut operations = AppStateLauncherPreviewOperations { state };
+            for event in output.events {
+                crate::app::persistence::options::launcher::dispatch_launcher_preview_event(
+                    &mut operations, event,
+                );
+            }
+        }
+        if let Some(result) = output.result {
+            let mut operations = AppStateLauncherParentOperations { state };
+            crate::app::persistence::options::launcher::dispatch_launcher_parent_result(
+                &mut operations, dialog, result,
+            );
+        } else {
+            state.frontend.options_dialog = Some(dialog);
+        }
+    }
+
+    pub(crate) fn handle_launcher_options_mouse(state: &mut AppState, down: Option<bool>) {
+        let Some(mut dialog) = state.frontend.options_dialog.take() else { return; };
+        let (x, y) = (state.match_state.input.cursor_x as i32, state.match_state.input.cursor_y as i32);
+        let (w, h) = (state.render_width() as i32, state.render_height() as i32);
+        match down {
+            Some(true) => dialog.shell_mouse_down(x, y, w, h),
+            Some(false) => dialog.shell_mouse_up(x, y, w, h),
+            None => dialog.shell_mouse_move(x, y, w, h),
+        }
+        let output = dialog.drain_output();
+        Self::dispatch_launcher_options_output(state, dialog, output);
+        state.platform.window.request_redraw();
     }
 
     /// Pump-terminal completion enters the same always-apply parent transaction
@@ -1131,25 +1179,7 @@ impl App {
                 &state.renderer.egui.ctx,
                 &mut dialog,
             );
-            {
-                let mut operations = AppStateLauncherPreviewOperations { state };
-                for event in output.events {
-                    crate::app::persistence::options::launcher::dispatch_launcher_preview_event(
-                        &mut operations,
-                        event,
-                    );
-                }
-            }
-            if let Some(result) = output.result {
-                let mut operations = AppStateLauncherParentOperations { state };
-                crate::app::persistence::options::launcher::dispatch_launcher_parent_result(
-                    &mut operations,
-                    dialog,
-                    result,
-                );
-            } else {
-                state.frontend.options_dialog = Some(dialog);
-            }
+            Self::dispatch_launcher_options_output(state, dialog, output);
             return false;
         }
 

--- a/src/render/bit_font.rs
+++ b/src/render/bit_font.rs
@@ -310,9 +310,9 @@ impl BitFont {
         let mut line_x: u32 = 0;
         let mut chars_on_line: u32 = 0;
         let mut max_line_width: u32 = 0;
-        let mut last_space_byte: Option<usize> = None;
-        let mut last_space_byte_after: usize = 0;
-        let mut last_space_x: u32 = 0;
+        // Character index and measured width before the break. Keep the
+        // scanner restart and UTF-8 byte boundary tied to the same character.
+        let mut last_space: Option<(usize, u32)> = None;
         let mut prev_char: Option<char> = None;
         let mut y_lines: u32 = 1;
 
@@ -346,16 +346,14 @@ impl BitFont {
                     line_start_byte = next_byte_off;
                     line_x = 0;
                     chars_on_line = 0;
-                    last_space_byte = None;
+                    last_space = None;
                     y_lines += 1;
                     prev_char = Some(ch);
                     i += 1;
                     continue;
                 }
                 ' ' => {
-                    last_space_byte = Some(byte_off);
-                    last_space_byte_after = next_byte_off;
-                    last_space_x = line_x;
+                    last_space = Some((i, line_x));
                 }
                 _ => {}
             }
@@ -382,31 +380,44 @@ impl BitFont {
                 chars_on_line = 1;
                 prev_char = Some(ch);
                 i += 1;
-            } else if let Some(space_b) = last_space_byte {
+            } else if let Some((space_index, space_x)) = last_space {
                 lines.push(LineSpan {
                     start_byte: line_start_byte,
-                    end_byte: space_b,
-                    width: last_space_x,
+                    end_byte: chars[space_index].0,
+                    width: space_x,
                 });
-                max_line_width = max_line_width.max(last_space_x);
-                line_start_byte = last_space_byte_after;
+                max_line_width = max_line_width.max(space_x);
+                // gamemd 434F60..434F64 rewinds the scanner to the saved
+                // space; 4350F5..435103 and 43512D..435138 resume after it.
+                // Retrying only the overflow character either revisits an
+                // already consumed space or skips measuring a word prefix.
+                // Native comparison: tools/storage_oracle/shell_text_lines.py.
+                i = space_index + 1;
+                line_start_byte = chars.get(i).map(|c| c.0).unwrap_or(text.len());
                 line_x = 0;
                 chars_on_line = 0;
-                last_space_byte = None;
+                last_space = None;
+                prev_char = Some(' ');
                 y_lines += 1;
-                // do not advance i -- retry char on new line
             } else {
+                // Native 434F6F..434F78 excludes the preceding fitting unit
+                // from this line's emission. 43512D..435138 nevertheless
+                // resumes measurement at the overflowing unit. Preserve the
+                // separate emission start and scan cursor; remeasuring the
+                // deferred glyph changes subsequent native line boundaries.
+                let deferred_byte = chars[i - 1].0;
                 lines.push(LineSpan {
                     start_byte: line_start_byte,
-                    end_byte: byte_off,
+                    end_byte: deferred_byte,
                     width: line_x,
                 });
                 max_line_width = max_line_width.max(line_x);
-                line_start_byte = byte_off;
+                line_start_byte = deferred_byte;
                 line_x = 0;
                 chars_on_line = 0;
                 y_lines += 1;
-                // do not advance i
+                // Retry the overflow character; the deferred glyph remains
+                // in the emitted span without being measured a second time.
             }
         }
         lines.push(LineSpan {

--- a/src/render/shell_text.rs
+++ b/src/render/shell_text.rs
@@ -118,8 +118,13 @@ pub fn draw_in_rect(
     // in left-to-right from the centered start position. `None` reveal leaves
     // the per-line output byte-identical to the steady-state path.
     let mut consumed: u32 = 0;
-    for span in &layout.lines {
-        if (line_y + font.glyph_height()) > (rect.y as f32 + rect.h as f32) {
+    for (line_index, span) in layout.lines.iter().enumerate() {
+        // 434CD0 paints the first line before consulting max-height. Its
+        // newline/wrap tails (434EC2..434ED7 /435112..435127) stop only after
+        // consumed cell advances reach the nonzero limit. The raster scissor
+        // clips overhanging glyph pixels; a short clip must not discard an
+        // admitted line. Retail GAME.FNT has16 bitmap rows and17px cell advance.
+        if line_index > 0 && rect.h != 0 && line_index as f32 * line_advance >= rect.h as f32 {
             break;
         }
         if let Some(r) = reveal {
@@ -186,8 +191,9 @@ pub fn draw_in_rect_path_a(
     let mut instances = Vec::with_capacity(text.len());
     let mut consumed = 0u32;
 
-    for span in &layout.lines {
-        if line_y + font.glyph_height() > rect.y as f32 + rect.h as f32 {
+    for (line_index, span) in layout.lines.iter().enumerate() {
+        // Same original 434CD0 line admission as the non-reveal entry above.
+        if line_index > 0 && rect.h != 0 && line_index as f32 * line_advance >= rect.h as f32 {
             break;
         }
         let line_x_offset = if flags.contains(ShellAlign::H_CENTER) && span.width < rect.w {
@@ -222,6 +228,133 @@ mod tests {
 
     fn test_font() -> BitFont {
         make_test_font(&[(b'x' as u16, 6), (b'a' as u16, 6), (b'b' as u16, 6)], 4)
+    }
+
+    #[test]
+    fn line_submissions_match_original_434cd0_for_short_static_rectangles() {
+        let golden: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tools/storage_oracle/shell_text_lines.json"
+        ))
+        .unwrap();
+        let mut font = make_test_font(&[(b'A' as u16, 6)], 3);
+        font.cell_height = 17;
+        font.bitmap_rows = 16;
+        font.char_spacing = 0;
+        let cases = golden["cases"].as_array().unwrap();
+        assert_eq!(cases.len(), 66);
+        for case in cases {
+            let rect = TextRect {
+                x: 11,
+                y: 13,
+                w: case["width"].as_u64().unwrap() as u32,
+                h: case["height"].as_u64().unwrap() as u32,
+            };
+            let text = case["text"].as_str().unwrap();
+            let plain = draw_in_rect(
+                &font,
+                text,
+                rect,
+                [1.0; 3],
+                ShellAlign::NONE,
+                [0.0; 2],
+                0.5,
+                None,
+            );
+            let reveal = draw_in_rect_path_a(
+                &font,
+                text,
+                rect,
+                ShellAlign::NONE,
+                [0.0; 2],
+                0.5,
+                PathAReveal {
+                    count: 0,
+                    range: 8,
+                    base_rgb: [255; 3],
+                    highlight_rgb: [255; 3],
+                },
+            );
+            let expected: Vec<_> = case["submissions"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|p| {
+                    [
+                        p["x"].as_u64().unwrap() as f32,
+                        p["y"].as_u64().unwrap() as f32,
+                    ]
+                })
+                .collect();
+            for draw in [plain, reveal] {
+                let positions: Vec<_> = draw.instances.iter().map(|i| i.position).collect();
+                assert_eq!(positions, expected, "{case}");
+                assert_eq!(draw.scissor.h, rect.h);
+            }
+        }
+    }
+
+    #[test]
+    fn short_native_static_keeps_first_line_and_clips_pixels_in_both_paths() {
+        let font = test_font();
+        let rect = TextRect {
+            x: 10,
+            y: 20,
+            w: 100,
+            h: 1,
+        };
+        let plain = draw_in_rect(
+            &font,
+            "x\nx",
+            rect,
+            [1.0; 3],
+            ShellAlign::NONE,
+            [0.0; 2],
+            0.5,
+            None,
+        );
+        let reveal = draw_in_rect_path_a(
+            &font,
+            "x\nx",
+            rect,
+            ShellAlign::NONE,
+            [0.0; 2],
+            0.5,
+            PathAReveal {
+                count: 0,
+                range: 8,
+                base_rgb: [255; 3],
+                highlight_rgb: [255; 3],
+            },
+        );
+        for draw in [plain, reveal] {
+            assert_eq!(draw.instances.len(), 1);
+            assert_eq!(draw.scissor.h, 1);
+            assert!(draw.instances[0].size[1] > 1.0);
+        }
+    }
+
+    #[test]
+    fn native_height_limit_counts_cell_advances_independent_of_vertical_center() {
+        let font = test_font();
+        let h = font.cell_height() as u32 + 1;
+        for align in [ShellAlign::NONE, ShellAlign::V_CENTER] {
+            let draw = draw_in_rect(
+                &font,
+                "x\nx\nx",
+                TextRect {
+                    x: 0,
+                    y: 0,
+                    w: 100,
+                    h,
+                },
+                [1.0; 3],
+                align,
+                [0.0; 2],
+                0.5,
+                None,
+            );
+            assert_eq!(draw.instances.len(), 2);
+        }
     }
 
     fn rect_100x30() -> TextRect {
@@ -336,8 +469,13 @@ mod tests {
             0.5,
             None,
         );
-        assert_eq!(draw.instances.len(), 1, "second line is past the rect");
+        // Native height admission counts cell advances independently of the
+        // centering offset: 17 < 30 admits line two, then the scissor clips it.
+        assert_eq!(draw.instances.len(), 2);
         assert_eq!(draw.instances[0].position[1], -2.0);
+        assert_eq!(draw.instances[1].position[1], 15.0);
+        assert_eq!(draw.scissor.y, 0);
+        assert_eq!(draw.scissor.h, 30);
         assert_eq!(vcenter_offset(30, 34), -2.0);
         // C++ integer division truncates toward zero for negatives.
         assert_eq!(vcenter_offset(10, 13), -1.0);

--- a/src/render/skirmish_shell_chrome.rs
+++ b/src/render/skirmish_shell_chrome.rs
@@ -49,6 +49,8 @@ pub struct SkirmishShellChromeAtlas {
     /// `None` when the loaded SHP lacks that frame (draw clamps, never panics).
     pub right_panel_button_sdbtnanm_frames: [Option<SkirmishShellChromeEntry>; 17],
     pub right_panel_bottom_sdbtm: Option<SkirmishShellChromeEntry>,
+    /// D5 static71C: 6038F7->6039EF selects SDWRNANM through SHELL2.PAL.
+    pub launcher_warning_frames: Vec<SkirmishShellChromeEntry>,
     pub sd_map_button: Option<SkirmishShellChromeEntry>,
     pub background_640_mnscrns: Option<SkirmishShellChromeEntry>,
     pub background_800_coop_game_setup: Option<SkirmishShellChromeEntry>,
@@ -94,6 +96,9 @@ pub struct SkirmishShellChromeAtlas {
     /// Both adjacent border-2 primitive frames drawn around a `128x21`
     /// owner-draw trackbar, including the two-pixel outside expansion.
     pub trackbar_rail: Option<SkirmishShellChromeEntry>,
+    /// Launcher D5 plain 180x21 trackbar (4AC disables the value plaque).
+    pub trackbar_plain_180: Option<SkirmishShellChromeEntry>,
+    pub combo_face_180: Option<SkirmishShellChromeEntry>,
     pub combo_face_150: Option<SkirmishShellChromeEntry>,
     pub combo_face_117: Option<SkirmishShellChromeEntry>,
     pub combo_face_44: Option<SkirmishShellChromeEntry>,
@@ -115,6 +120,8 @@ pub struct ControlChrome {
     pub checkbox_unchecked_cue_i: Option<SkirmishShellChromeEntry>,
     pub checkbox_checked_cce_i: Option<SkirmishShellChromeEntry>,
     pub trackbar_rail: Option<SkirmishShellChromeEntry>,
+    pub trackbar_plain_180: Option<SkirmishShellChromeEntry>,
+    pub combo_face_180: Option<SkirmishShellChromeEntry>,
     pub trackbar_plaque_left_trofl: Option<SkirmishShellChromeEntry>,
     pub trackbar_plaque_mid_trofm: Option<SkirmishShellChromeEntry>,
     pub trackbar_plaque_right_trofr: Option<SkirmishShellChromeEntry>,
@@ -148,6 +155,8 @@ impl SkirmishShellChromeAtlas {
             checkbox_unchecked_cue_i: self.checkbox_unchecked_cue_i,
             checkbox_checked_cce_i: self.checkbox_checked_cce_i,
             trackbar_rail: self.trackbar_rail,
+            trackbar_plain_180: self.trackbar_plain_180,
+            combo_face_180: self.combo_face_180,
             trackbar_plaque_left_trofl: self.trackbar_plaque_left_trofl,
             trackbar_plaque_mid_trofm: self.trackbar_plaque_mid_trofm,
             trackbar_plaque_right_trofr: self.trackbar_plaque_right_trofr,
@@ -211,6 +220,20 @@ pub fn build_skirmish_shell_chrome_atlas(
     let choose_map_background_palette = load_choose_map_background_palette(assets);
 
     let mut rendered = Vec::new();
+    // Original SDWRNANM header supplies 91 frames; keep the runtime sequence
+    // bounded by the available retail frames, without stretching the canvas.
+    for frame in 0..91 {
+        let Some(entry) = render_shp_entry_labeled(
+            assets,
+            "SDWRNANM.SHP",
+            &format!("sdwrnanm.shp#{frame}"),
+            &shell2_palette,
+            frame,
+        ) else {
+            break;
+        };
+        rendered.push(entry);
+    }
     rendered.push(mandatory_shp(
         assets,
         "SDTP.SHP",
@@ -420,8 +443,15 @@ pub fn build_skirmish_shell_chrome_atlas(
     }
 
     rendered.push(render_trackbar_frame_entry("skirmish_trackbar_rail"));
+    rendered.push(render_trackbar_frame_geometry(
+        "launcher_trackbar_plain_180",
+        180,
+        21,
+        0,
+    ));
     for (label, width) in [
         ("skirmish_combo_face_150", 150),
+        ("launcher_combo_face_180", 180),
         ("skirmish_combo_face_117", 117),
         ("skirmish_combo_face_44", 44),
         ("skirmish_combo_face_38", 38),
@@ -463,6 +493,9 @@ pub fn build_skirmish_shell_chrome_atlas(
 
     Some(SkirmishShellChromeAtlas {
         texture,
+        launcher_warning_frames: (0..91)
+            .map_while(|frame| by_label.get(&format!("sdwrnanm.shp#{frame}")).copied())
+            .collect(),
         right_panel_top_sdtp: by_label.get("sdtp.shp").copied(),
         right_panel_top_highlight_sdtp_frame1: by_label.get("sdtp.shp#1").copied(),
         right_panel_tile_sdbtnbkgd: by_label.get("sdbtnbkgd.shp").copied(),
@@ -515,6 +548,8 @@ pub fn build_skirmish_shell_chrome_atlas(
         scrollbar_thumb_mid: by_label.get("sbgripm.pcx").copied(),
         scrollbar_thumb_bottom: by_label.get("sbgripb.pcx").copied(),
         trackbar_rail: by_label.get("skirmish_trackbar_rail").copied(),
+        trackbar_plain_180: by_label.get("launcher_trackbar_plain_180").copied(),
+        combo_face_180: by_label.get("launcher_combo_face_180").copied(),
         combo_face_150: by_label.get("skirmish_combo_face_150").copied(),
         combo_face_117: by_label.get("skirmish_combo_face_117").copied(),
         combo_face_44: by_label.get("skirmish_combo_face_44").copied(),
@@ -741,16 +776,33 @@ fn render_primitive_bevel_entry(
 }
 
 fn render_trackbar_frame_entry(label: &str) -> RenderedShellEntry {
+    render_trackbar_frame_geometry(
+        label,
+        TRACKBAR_CONTROL_W,
+        TRACKBAR_CONTROL_H,
+        TRACKBAR_VALUE_PLAQUE_W,
+    )
+}
+
+/// Original 61E1B9..61E269: draw the rail frame at the current control size;
+/// only a plaque-enabled control draws the adjacent value frame. Both use
+/// 6208F0's two-pixel outside expansion. Never stretch a split-frame bitmap.
+fn render_trackbar_frame_geometry(
+    label: &str,
+    control_width: u32,
+    control_height: u32,
+    reserve: i32,
+) -> RenderedShellEntry {
     let border = TRACKBAR_FRAME_BORDER;
-    let width = TRACKBAR_CONTROL_W + (border as u32) * 2;
-    let height = TRACKBAR_CONTROL_H + (border as u32) * 2;
+    let width = control_width + (border as u32) * 2;
+    let height = control_height + (border as u32) * 2;
     let mut rgba = vec![0u8; (width * height * 4) as usize];
 
-    let control_w = TRACKBAR_CONTROL_W as i32;
-    let control_h = TRACKBAR_CONTROL_H as i32;
-    let left_frame_w = control_w - TRACKBAR_VALUE_PLAQUE_W;
+    let control_w = control_width as i32;
+    let control_h = control_height as i32;
+    let left_frame_w = control_w - reserve;
     let value_frame_x = left_frame_w + TRACKBAR_VALUE_FRAME_INSET;
-    let value_frame_w = TRACKBAR_VALUE_PLAQUE_W - TRACKBAR_VALUE_FRAME_INSET;
+    let value_frame_w = reserve - TRACKBAR_VALUE_FRAME_INSET;
 
     // `OwnerDraw_Trackbar_0061D950` supplies control-relative boxes and
     // FUN_006208F0 expands each by two pixels. Shift both inputs by the canvas
@@ -762,13 +814,15 @@ fn render_trackbar_frame_entry(label: &str) -> RenderedShellEntry {
         [border, border, left_frame_w, control_h],
         border,
     );
-    draw_primitive_bevel(
-        &mut rgba,
-        width,
-        height,
-        [border + value_frame_x, border, value_frame_w, control_h],
-        border,
-    );
+    if reserve > 0 {
+        draw_primitive_bevel(
+            &mut rgba,
+            width,
+            height,
+            [border + value_frame_x, border, value_frame_w, control_h],
+            border,
+        );
+    }
 
     RenderedShellEntry {
         label: label.to_ascii_lowercase(),

--- a/src/ui/main_menu_dialogs/options.rs
+++ b/src/ui/main_menu_dialogs/options.rs
@@ -5,6 +5,8 @@
 
 use crate::ui::client_theme;
 
+pub(crate) mod shell;
+
 /// gamemd-derived: launcher owner `OptionsClass__ShowLauncherDialog @
 /// 0x0055FC80` and its primary-proc slice `0x0055FDB0..0x0056047A` bind the
 /// RT_DIALOG `0xD5` controls to these launcher-local CSF keys/fallbacks.
@@ -339,6 +341,7 @@ pub(crate) enum LauncherCue {
     GenericClick,
     Checkbox,
     ComboOpen,
+    ComboClose,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -654,7 +657,10 @@ pub(crate) fn trackbar_position_from_x(
 
 fn thumb_left(position: u8, client_width: i32, reserve: i32, maximum: u8) -> i32 {
     let usable_span = (client_width - reserve - 13).max(1);
-    1 + i32::from(position) * usable_span / (i32::from(maximum) + 1)
+    // Original 0x0061E486..0x0061E4A8 (TBM_SETPOS) and
+    // 0x0061DC44..0x0061DC58 (drag) divide the painted offset by range.
+    // Mouse quantization above deliberately uses range + 1 instead.
+    1 + i32::from(position) * usable_span / i32::from(maximum).max(1)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -671,6 +677,7 @@ pub(crate) struct OptionsDialogState {
     capture: Option<LauncherTrackbarId>,
     pending_events: Vec<LauncherOptionsEvent>,
     pending_result: Option<LauncherParentResult>,
+    shell_interaction: shell::ShellInteraction,
 }
 
 impl Default for OptionsDialogState {
@@ -720,6 +727,7 @@ impl OptionsDialogState {
             capture: None,
             pending_events: Vec::new(),
             pending_result: None,
+            shell_interaction: shell::ShellInteraction::default(),
         }
     }
 
@@ -1955,6 +1963,53 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn launcher_trackbar_position_and_painted_thumb_match_original_instruction_goldens() {
+        // Reproduced by tools/storage_oracle/launcher_trackbar.py from the
+        // hash-checked retail executable. This compares the separate native
+        // range+1 pointer partition and range-only retained paint calculation.
+        let golden: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../tools/storage_oracle/launcher_trackbar.json"
+        ))
+        .unwrap();
+        let geometries = golden["geometries"].as_array().unwrap();
+        assert_eq!(geometries.len(), 16);
+        let integer = |value: &serde_json::Value, key: &str| value[key].as_i64().unwrap() as i32;
+        let mut position_count = 0;
+        let mut pointer_count = 0;
+        for geometry in geometries {
+            let width = integer(geometry, "width");
+            let reserve = integer(geometry, "reserve");
+            let maximum = integer(geometry, "maximum") as u8;
+            for sample in geometry["positions"].as_array().unwrap() {
+                let position = integer(sample, "position") as u8;
+                let left = thumb_left(position, width, reserve, maximum);
+                assert_eq!(
+                    left,
+                    integer(sample, "thumb_left"),
+                    "{geometry:?} {sample:?}"
+                );
+                assert_eq!(left + 12, integer(sample, "thumb_right"));
+                position_count += 1;
+            }
+            for sample in geometry["pointers"].as_array().unwrap() {
+                let x = integer(sample, "x");
+                let position = trackbar_position_from_x(x, width, reserve, maximum);
+                assert_eq!(
+                    i32::from(position),
+                    integer(sample, "position"),
+                    "width={width} reserve={reserve} maximum={maximum} x={x}"
+                );
+                let left = thumb_left(position, width, reserve, maximum);
+                assert_eq!(left, integer(sample, "thumb_left"));
+                assert_eq!(left + 12, integer(sample, "thumb_right"));
+                pointer_count += 1;
+            }
+        }
+        assert_eq!(position_count, 92);
+        assert_eq!(pointer_count, 2736);
     }
 
     #[test]

--- a/src/ui/main_menu_dialogs/options/shell.rs
+++ b/src/ui/main_menu_dialogs/options/shell.rs
@@ -1,0 +1,599 @@
+//! Physical-pixel presentation and input for launcher resource 0xD5.
+//!
+//! Retail RT_DIALOG/0xD5/1033 provides the DLU rectangles; common setup
+//! 0x00608CD0/0x00609730 anchors the rail, and 0x0060B950 adjusts its title.
+//! This module projects the retained OptionsDialogState instead of owning a
+//! second set of option values or bypassing its ordered preview events.
+
+use super::{
+    LauncherCheckboxId, LauncherCue, LauncherOptionsEvent, LauncherParentResult,
+    LauncherResolutionRow, LauncherTrackbarId, OptionsDialogState, PhysicalControlFrame,
+    thumb_left,
+};
+use crate::ui::shell::geom::{RectPx, center_offset, dlu_rect};
+use crate::ui::skirmish_shell::{
+    COMBO_DROPDOWN_ROW_H, COMBO_DROPDOWN_SCROLLBAR_BUTTON_H, COMBO_DROPDOWN_SCROLLBAR_W,
+    COMBO_FACE_H, ScrollModel,
+};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct ShellInteraction {
+    hovered_button: Option<LauncherParentResult>,
+    pressed_button: Option<LauncherParentResult>,
+    popup_hovered: Option<usize>,
+    popup_top: usize,
+    popup_scroll_grab: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LauncherOptionsLayout {
+    pub(crate) title: RectPx,
+    pub(crate) warning: RectPx,
+    pub(crate) resolution: RectPx,
+    pub(crate) trackbars: [(LauncherTrackbarId, RectPx); 6],
+    pub(crate) checkboxes: [(LauncherCheckboxId, RectPx); 3],
+    pub(crate) buttons: [(LauncherParentResult, RectPx); 3],
+    offset_x: i32,
+    offset_y: i32,
+}
+
+impl LauncherOptionsLayout {
+    pub(crate) fn new(width: i32, height: i32) -> Self {
+        let offset_x = center_offset(width, 800);
+        let offset_y = center_offset(height, 600);
+        let px = |rect: RectPx| rect.translate(offset_x, offset_y);
+        let dlu = |x, y, w, h| px(dlu_rect(x, y, w, h));
+        Self {
+            title: px(RectPx::new(635, 9, 162, 17)),
+            warning: px(RectPx::new(670, 47, 92, 54)),
+            resolution: px(RectPx::new(351, 86, 180, COMBO_FACE_H)),
+            trackbars: [
+                (LauncherTrackbarId::Detail, dlu(89, 53, 120, 13)),
+                (LauncherTrackbarId::Difficulty, dlu(92, 128, 120, 13)),
+                (LauncherTrackbarId::Scroll, dlu(238, 203, 120, 13)),
+                (LauncherTrackbarId::Score, dlu(82, 289, 85, 13)),
+                (LauncherTrackbarId::Sound, dlu(179, 289, 85, 13)),
+                (LauncherTrackbarId::Voice, dlu(277, 289, 85, 13)),
+            ],
+            checkboxes: [
+                (LauncherCheckboxId::Tooltips, dlu(93, 188, 130, 10)),
+                (LauncherCheckboxId::TargetLines, dlu(93, 203, 130, 10)),
+                (LauncherCheckboxId::ShowHidden, dlu(93, 218, 130, 10)),
+            ],
+            buttons: [
+                (
+                    LauncherParentResult::Keyboard,
+                    px(RectPx::new(644, 199, 156, 42)),
+                ),
+                (
+                    LauncherParentResult::Network,
+                    px(RectPx::new(644, 241, 156, 42)),
+                ),
+                (
+                    LauncherParentResult::Back,
+                    px(RectPx::new(644, 535, 156, 42)),
+                ),
+            ],
+            offset_x,
+            offset_y,
+        }
+    }
+
+    fn label_rect(&self, x: i32, y: i32, w: i32, h: i32) -> RectPx {
+        dlu_rect(x, y, w, h).translate(self.offset_x, self.offset_y)
+    }
+
+    fn trackbar_rect(&self, id: LauncherTrackbarId) -> RectPx {
+        self.trackbars
+            .iter()
+            .find(|(candidate, _)| *candidate == id)
+            .unwrap()
+            .1
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LauncherLabelAlign {
+    Left,
+    Center,
+    Right,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LauncherShellLabel<'a> {
+    pub(crate) rect: RectPx,
+    pub(crate) text: &'a str,
+    pub(crate) align: LauncherLabelAlign,
+    pub(crate) title: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LauncherResolutionPopup {
+    pub(crate) rect: RectPx,
+    pub(crate) content: RectPx,
+    pub(crate) row_height: i32,
+    pub(crate) first_row: usize,
+    pub(crate) visible_rows: usize,
+    pub(crate) scrollbar: Option<RectPx>,
+    pub(crate) thumb: Option<RectPx>,
+    pub(crate) selected: Option<usize>,
+    pub(crate) hovered: Option<usize>,
+}
+
+impl LauncherResolutionPopup {
+    fn row_at(self, x: i32, y: i32) -> Option<usize> {
+        self.content
+            .contains(x, y)
+            .then(|| self.first_row + ((y - self.content.y) / self.row_height) as usize)
+    }
+}
+
+fn frame(rect: RectPx, x: i32, y: i32) -> PhysicalControlFrame {
+    PhysicalControlFrame {
+        local_x: x - rect.x,
+        local_y: y - rect.y,
+        width: rect.w,
+        height: rect.h,
+    }
+}
+
+impl OptionsDialogState {
+    /// Native61E3AF..61E44E drops held/drag state once MK_LBUTTON is absent.
+    /// Focus loss is the host's authoritative lost-gesture boundary.
+    pub(crate) fn shell_cancel_pointer_gesture(&mut self) {
+        self.capture = None;
+        self.shell_interaction.pressed_button = None;
+        self.shell_interaction.hovered_button = None;
+        self.shell_interaction.popup_scroll_grab = None;
+    }
+    pub(crate) fn shell_labels(
+        &self,
+        layout: &LauncherOptionsLayout,
+    ) -> Vec<LauncherShellLabel<'_>> {
+        use LauncherLabelAlign::{Center, Left, Right};
+        let labels = &self.labels;
+        let mut result = vec![LauncherShellLabel {
+            rect: layout.title,
+            text: &labels.options,
+            align: Center,
+            title: true,
+        }];
+        for (text, x, y, w, h, align) in [
+            (labels.display_options.as_str(), 20, 18, 140, 10, Left),
+            (&labels.game_options, 20, 93, 298, 10, Left),
+            (&labels.ui_options, 20, 168, 298, 10, Left),
+            (&labels.audio_options, 20, 254, 298, 10, Left),
+            (&labels.visual_details, 89, 38, 60, 10, Left),
+            (&self.detail_caption, 149, 38, 60, 10, Right),
+            (&labels.set_resolution, 234, 38, 120, 10, Left),
+            (&labels.difficulty, 92, 113, 60, 10, Left),
+            (&self.difficulty_caption, 152, 113, 60, 10, Right),
+            (&labels.scroll_rate, 238, 188, 60, 10, Left),
+            (&self.scroll_caption, 298, 188, 60, 10, Right),
+            (&labels.music_volume, 82, 274, 85, 10, Center),
+            (&labels.sound_volume, 179, 274, 85, 10, Center),
+            (&labels.voice_volume, 277, 274, 85, 10, Center),
+            (&labels.blank, 2, 355, 303, 12, Left),
+        ] {
+            result.push(LauncherShellLabel {
+                rect: layout.label_rect(x, y, w, h),
+                text,
+                align,
+                title: false,
+            });
+        }
+        result
+    }
+
+    pub(crate) fn shell_checkbox_label(&self, id: LauncherCheckboxId) -> &str {
+        match id {
+            LauncherCheckboxId::Tooltips => &self.labels.tooltips,
+            LauncherCheckboxId::TargetLines => &self.labels.target_lines,
+            LauncherCheckboxId::ShowHidden => &self.labels.show_hidden,
+        }
+    }
+
+    pub(crate) fn shell_button_label(&self, id: LauncherParentResult) -> &str {
+        match id {
+            LauncherParentResult::Keyboard => &self.labels.keyboard,
+            LauncherParentResult::Network => &self.labels.network,
+            LauncherParentResult::Back => &self.labels.main_menu,
+            LauncherParentResult::Terminal => "",
+        }
+    }
+
+    pub(crate) fn shell_title_text(&self) -> &str {
+        &self.labels.options
+    }
+
+    pub(crate) fn shell_trackbar_thumb_left(&self, id: LauncherTrackbarId, width: i32) -> i32 {
+        thumb_left(
+            self.trackbar_position(id),
+            width,
+            id.plaque_reserve(),
+            id.maximum(),
+        )
+    }
+
+    pub(crate) fn shell_checkbox_checked(&self, id: LauncherCheckboxId) -> bool {
+        match id {
+            LauncherCheckboxId::Tooltips => self.values.tooltips,
+            LauncherCheckboxId::TargetLines => self.values.target_lines,
+            LauncherCheckboxId::ShowHidden => self.values.show_hidden,
+        }
+    }
+
+    pub(crate) fn shell_selected_resolution_text(&self) -> &str {
+        self.selected_resolution_label()
+    }
+    pub(crate) fn shell_resolution_rows(&self) -> &[LauncherResolutionRow] {
+        &self.resolution_rows
+    }
+    pub(crate) fn shell_button_hovered(&self, id: LauncherParentResult) -> bool {
+        self.shell_interaction.hovered_button == Some(id)
+    }
+    pub(crate) fn shell_button_pressed(&self, id: LauncherParentResult) -> bool {
+        self.shell_interaction.pressed_button == Some(id) && self.shell_button_hovered(id)
+    }
+
+    pub(crate) fn shell_popup(
+        &self,
+        layout: &LauncherOptionsLayout,
+    ) -> Option<LauncherResolutionPopup> {
+        if !self.resolution_popup_open || self.resolution_rows.is_empty() {
+            return None;
+        }
+        // Original ComboDropWin creation 0x006180CF..0x00618205 truncates
+        // the retained dropped allocation to whole item-height rows. D5 has
+        // 74 DLU (120px) allocated, admitting five 23px rows. Actual HWND
+        // border adjustments remain outside this resource-derived bound.
+        let model = ScrollModel::combo(5);
+        let visible_rows = model.visible_rows(self.resolution_rows.len(), 0);
+        let rect = RectPx::new(
+            layout.resolution.x,
+            layout.resolution.y + COMBO_FACE_H + 1,
+            layout.resolution.w,
+            visible_rows as i32 * COMBO_DROPDOWN_ROW_H,
+        );
+        let max_top = self.resolution_rows.len().saturating_sub(visible_rows);
+        let first_row = self.shell_interaction.popup_top.min(max_top);
+        let scrollbar = (max_top > 0).then(|| {
+            RectPx::new(
+                rect.x + rect.w - COMBO_DROPDOWN_SCROLLBAR_W,
+                rect.y,
+                COMBO_DROPDOWN_SCROLLBAR_W,
+                rect.h,
+            )
+        });
+        let thumb = scrollbar.and_then(|scrollbar| {
+            let height =
+                model.thumb_height(visible_rows, self.resolution_rows.len(), scrollbar.h)?;
+            Some(RectPx::new(
+                scrollbar.x,
+                model.thumb_y(scrollbar, height, first_row, max_top),
+                scrollbar.w,
+                height,
+            ))
+        });
+        Some(LauncherResolutionPopup {
+            rect,
+            content: RectPx::new(
+                rect.x,
+                rect.y,
+                rect.w - scrollbar.map_or(0, |s| s.w),
+                rect.h,
+            ),
+            row_height: COMBO_DROPDOWN_ROW_H,
+            first_row,
+            visible_rows,
+            scrollbar,
+            thumb,
+            selected: self.selected_resolution,
+            hovered: self.shell_interaction.popup_hovered,
+        })
+    }
+
+    /// The caller routes all pointer messages here while this parent is topmost.
+    pub(crate) fn shell_mouse_down(&mut self, x: i32, y: i32, width: i32, height: i32) {
+        let layout = LauncherOptionsLayout::new(width, height);
+        if self.capture.is_some() {
+            return;
+        }
+        if self.resolution_popup_open {
+            if let Some(popup) = self.shell_popup(&layout) {
+                if let Some(scrollbar) = popup.scrollbar.filter(|rect| rect.contains(x, y)) {
+                    let max_top = self
+                        .resolution_rows
+                        .len()
+                        .saturating_sub(popup.visible_rows);
+                    if y < scrollbar.y + COMBO_DROPDOWN_SCROLLBAR_BUTTON_H {
+                        self.shell_interaction.popup_top = popup.first_row.saturating_sub(1);
+                    } else if y >= scrollbar.y + scrollbar.h - COMBO_DROPDOWN_SCROLLBAR_BUTTON_H {
+                        self.shell_interaction.popup_top = (popup.first_row + 1).min(max_top);
+                    } else if let Some(thumb) = popup.thumb {
+                        if thumb.contains(x, y) {
+                            self.shell_interaction.popup_scroll_grab = Some(y - thumb.y);
+                        } else {
+                            self.shell_interaction.popup_top = ScrollModel::combo(5)
+                                .top_index_from_thumb_top(
+                                    scrollbar,
+                                    thumb.h,
+                                    max_top,
+                                    y - thumb.h / 2,
+                                );
+                        }
+                    }
+                    self.shell_interaction.popup_hovered = None;
+                    return;
+                }
+            }
+            // ComboDropWin 0x0060E4E9..0x0060E500 plays Rules+0x1A8
+            // (GUIComboCloseSound) before selection or outside dismissal;
+            // scrollbar forwarding above returns before this cue.
+            self.pending_events
+                .push(LauncherOptionsEvent::Cue(LauncherCue::ComboClose));
+            if let Some(index) = self
+                .shell_popup(&layout)
+                .and_then(|popup| popup.row_at(x, y))
+            {
+                self.select_resolution(index);
+            } else {
+                self.resolution_popup_open = false;
+            }
+            self.shell_interaction = ShellInteraction::default();
+            return;
+        }
+        self.shell_mouse_move(x, y, width, height);
+        if let Some((id, _)) = layout.buttons.iter().find(|(_, rect)| rect.contains(x, y)) {
+            self.shell_interaction.pressed_button = Some(*id);
+            self.main_button_mouse_down();
+        } else if let Some((id, rect)) = layout
+            .trackbars
+            .iter()
+            .find(|(_, rect)| rect.contains(x, y))
+        {
+            self.trackbar_mouse_down(*id, frame(*rect, x, y));
+        } else if let Some((id, rect)) = layout
+            .checkboxes
+            .iter()
+            .find(|(_, rect)| rect.contains(x, y))
+        {
+            self.checkbox_mouse_down(*id, frame(*rect, x, y));
+        } else if layout.resolution.contains(x, y) {
+            self.combo_mouse_down(frame(layout.resolution, x, y));
+            self.shell_interaction.hovered_button = None;
+            // The fresh custom popup record is zeroed. Its 0x7E8 refresh
+            // copies CB_GETCURSEL to highlight +E8, leaving top-index +F0
+            // zero (0x0060F276..0x0060F283).
+            self.shell_interaction.popup_top = 0;
+        }
+    }
+
+    pub(crate) fn shell_mouse_move(&mut self, x: i32, y: i32, width: i32, height: i32) {
+        let layout = LauncherOptionsLayout::new(width, height);
+        if let Some(id) = self.capture {
+            self.trackbar_mouse_move(id, frame(layout.trackbar_rect(id), x, y));
+            self.shell_interaction.hovered_button = None;
+            return;
+        }
+        if self.resolution_popup_open {
+            if let Some(grab) = self.shell_interaction.popup_scroll_grab {
+                if let Some(popup) = self.shell_popup(&layout) {
+                    if let (Some(scrollbar), Some(thumb)) = (popup.scrollbar, popup.thumb) {
+                        let max_top = self
+                            .resolution_rows
+                            .len()
+                            .saturating_sub(popup.visible_rows);
+                        self.shell_interaction.popup_top = ScrollModel::combo(5)
+                            .top_index_from_thumb_top(scrollbar, thumb.h, max_top, y - grab);
+                    }
+                }
+                self.shell_interaction.popup_hovered = None;
+                return;
+            }
+            self.shell_interaction.popup_hovered = self
+                .shell_popup(&layout)
+                .and_then(|popup| popup.row_at(x, y));
+            self.shell_interaction.hovered_button = None;
+        } else {
+            self.shell_interaction.hovered_button = layout
+                .buttons
+                .iter()
+                .find(|(_, rect)| rect.contains(x, y))
+                .map(|(id, _)| *id);
+        }
+    }
+
+    pub(crate) fn shell_mouse_up(&mut self, x: i32, y: i32, width: i32, height: i32) {
+        self.shell_interaction.popup_scroll_grab = None;
+        if let Some(id) = self.capture {
+            self.trackbar_mouse_up(id);
+        }
+        self.shell_mouse_move(x, y, width, height);
+        if let Some(id) = self.shell_interaction.pressed_button.take() {
+            if self.shell_interaction.hovered_button == Some(id) && !self.resolution_popup_open {
+                self.request_result(id);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::main_menu_dialogs::options::{
+        LauncherCue, LauncherOptionsEvent, LauncherOptionsLabels, LauncherOptionsValues,
+    };
+
+    fn state() -> OptionsDialogState {
+        OptionsDialogState::new(
+            LauncherOptionsLabels::resolve(&|_| None),
+            LauncherOptionsValues::default(),
+            vec![
+                LauncherResolutionRow::new(800, 600),
+                LauncherResolutionRow::new(1024, 768),
+            ],
+            Some(0),
+            true,
+        )
+    }
+
+    #[test]
+    fn physical_slider_capture_crosses_other_controls_without_activating_them() {
+        let mut state = state();
+        let layout = LauncherOptionsLayout::new(800, 600);
+        let rect = layout.trackbar_rect(LauncherTrackbarId::Score);
+        let thumb = state.shell_trackbar_thumb_left(LauncherTrackbarId::Score, rect.w);
+        state.shell_mouse_down(rect.x + thumb + 5, rect.y + 10, 800, 600);
+        assert_eq!(state.capture, Some(LauncherTrackbarId::Score));
+        state.shell_mouse_move(799, 550, 800, 600);
+        state.shell_mouse_up(799, 550, 800, 600);
+        assert_eq!(state.trackbar_position(LauncherTrackbarId::Score), 10);
+        assert_eq!(state.capture, None);
+        let output = state.drain_output();
+        assert_eq!(output.events, [LauncherOptionsEvent::ScorePreview(1.0)]);
+        assert_eq!(output.result, None);
+    }
+
+    #[test]
+    fn lost_focus_cancels_drag_before_pointer_reentry() {
+        let mut state = state();
+        // Fixture starts at4: original128px/50px plaque projection puts the
+        // thumb at client27 (screen150), so155 is inside its12px capture box.
+        state.shell_mouse_down(155, 475, 800, 600);
+        assert_eq!(state.capture, Some(LauncherTrackbarId::Score));
+        state.shell_cancel_pointer_gesture();
+        let before = state.pack();
+        state.shell_mouse_move(799, 550, 800, 600);
+        state.shell_mouse_up(799, 550, 800, 600);
+        assert_eq!(state.pack(), before);
+        assert!(state.drain_output().events.is_empty());
+    }
+
+    #[test]
+    fn rail_jump_and_checkbox_text_do_not_acquire_capture() {
+        let mut state = state();
+        state.shell_mouse_down(140, 210, 800, 600);
+        assert_eq!(
+            state.trackbar_position(LauncherTrackbarId::Difficulty),
+            1,
+            "native lower strip rejects y=2"
+        );
+        state.shell_mouse_down(140, 218, 800, 600);
+        assert_eq!(state.trackbar_position(LauncherTrackbarId::Difficulty), 0);
+        assert_eq!(state.capture, None);
+        state.shell_mouse_move(317, 218, 800, 600);
+        assert_eq!(state.trackbar_position(LauncherTrackbarId::Difficulty), 0);
+        state.shell_mouse_down(170, 310, 800, 600);
+        assert!(state.shell_checkbox_checked(LauncherCheckboxId::Tooltips));
+        state.shell_mouse_down(150, 310, 800, 600);
+        assert!(!state.shell_checkbox_checked(LauncherCheckboxId::Tooltips));
+        assert_eq!(
+            state.drain_output().events,
+            [
+                LauncherOptionsEvent::Cue(LauncherCue::GenericClick),
+                LauncherOptionsEvent::Cue(LauncherCue::Checkbox)
+            ]
+        );
+    }
+
+    #[test]
+    fn button_release_requires_the_pressed_button_and_popup_dismissal_consumes_click() {
+        let mut state = state();
+        state.shell_mouse_down(700, 210, 800, 600);
+        assert!(state.shell_button_pressed(LauncherParentResult::Keyboard));
+        state.shell_mouse_up(700, 250, 800, 600);
+        assert_eq!(state.drain_output().result, None);
+        state.shell_mouse_down(520, 95, 800, 600);
+        assert!(state.resolution_popup_open);
+        state.shell_mouse_down(700, 550, 800, 600);
+        state.shell_mouse_up(700, 550, 800, 600);
+        assert!(!state.resolution_popup_open);
+        let dismissed = state.drain_output();
+        assert_eq!(dismissed.result, None);
+        assert_eq!(
+            dismissed.events,
+            [
+                LauncherOptionsEvent::Cue(LauncherCue::ComboOpen),
+                LauncherOptionsEvent::Cue(LauncherCue::ComboClose)
+            ]
+        );
+        state.shell_mouse_down(700, 550, 800, 600);
+        let down = state.drain_output();
+        assert_eq!(
+            down.events,
+            [LauncherOptionsEvent::Cue(LauncherCue::MainButton)]
+        );
+        assert_eq!(down.result, None);
+        state.shell_mouse_up(700, 550, 800, 600);
+        assert_eq!(
+            state.drain_output().result,
+            Some(LauncherParentResult::Back)
+        );
+    }
+
+    #[test]
+    fn resolution_selection_uses_the_painted_row_and_emits_immediate_pair() {
+        let mut state = state();
+        let layout = LauncherOptionsLayout::new(800, 600);
+        state.shell_mouse_down(520, 95, 800, 600);
+        state.drain_output();
+        let popup = state.shell_popup(&layout).unwrap();
+        let x = popup.rect.x + 10;
+        let y = popup.rect.y + popup.row_height + 5;
+        state.shell_mouse_move(x, y, 800, 600);
+        assert_eq!(state.shell_popup(&layout).unwrap().hovered, Some(1));
+        state.shell_mouse_down(x, y, 800, 600);
+        assert_eq!(state.shell_selected_resolution_text(), "1024 x 768 x 16");
+        assert!(state.shell_popup(&layout).is_none());
+        assert_eq!(
+            state.drain_output().events,
+            [
+                LauncherOptionsEvent::Cue(LauncherCue::ComboClose),
+                LauncherOptionsEvent::ResolutionSelected {
+                    width: 1024,
+                    height: 768
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn resolution_popup_scroll_reaches_later_rows_without_selecting_under_scrollbar() {
+        let mut state = state();
+        state.resolution_rows = (0..8)
+            .map(|index| LauncherResolutionRow::new(800 + index * 100, 600))
+            .collect();
+        let layout = LauncherOptionsLayout::new(800, 600);
+        state.shell_mouse_down(520, 95, 800, 600);
+        state.drain_output();
+        let popup = state.shell_popup(&layout).unwrap();
+        assert_eq!(popup.visible_rows, 5);
+        assert_eq!(popup.rect.h, 115);
+        let scrollbar = popup.scrollbar.unwrap();
+        for _ in 0..3 {
+            state.shell_mouse_down(scrollbar.x + 5, scrollbar.y + scrollbar.h - 5, 800, 600);
+            state.shell_mouse_up(scrollbar.x + 5, scrollbar.y + scrollbar.h - 5, 800, 600);
+        }
+        let popup = state.shell_popup(&layout).unwrap();
+        assert_eq!(popup.first_row, 3);
+        assert!(state.drain_output().events.is_empty());
+        state.shell_mouse_down(
+            popup.content.x + 5,
+            popup.content.y + 4 * popup.row_height + 5,
+            800,
+            600,
+        );
+        assert_eq!(state.shell_selected_resolution_text(), "1500 x 600 x 16");
+        assert_eq!(
+            state.drain_output().events,
+            [
+                LauncherOptionsEvent::Cue(LauncherCue::ComboClose),
+                LauncherOptionsEvent::ResolutionSelected {
+                    width: 1500,
+                    height: 600
+                }
+            ]
+        );
+    }
+}

--- a/src/ui/skirmish_shell/mod.rs
+++ b/src/ui/skirmish_shell/mod.rs
@@ -6,6 +6,7 @@
 
 mod layout;
 mod scroll;
+pub(crate) use scroll::ScrollModel;
 mod state;
 pub mod static_reveal;
 

--- a/tools/storage_oracle/launcher_trackbar.json
+++ b/tools/storage_oracle/launcher_trackbar.json
@@ -1,0 +1,17025 @@
+{
+  "geometries": [
+    {
+      "maximum": 1,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 29
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 30
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 31
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 32
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 33
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 34
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 35
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 36
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 37
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 38
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 39
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 40
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 41
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 42
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 43
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 44
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 45
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 46
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 47
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 48
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 49
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 50
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 51
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 52
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 53
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 54
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 55
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 56
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 57
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 58
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 59
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 60
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 61
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 62
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 63
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 64
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 65
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 66
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 67
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 68
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 69
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 70
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 71
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 72
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 73
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 74
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 75
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 76
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 77
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 78
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 79
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 80
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 81
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 82
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 83
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 84
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 85
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 86
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 87
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 88
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 89
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 90
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 91
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 92
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 93
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 94
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 95
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 96
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 97
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 98
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 99
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 100
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 101
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 102
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 103
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 104
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 105
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 106
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 107
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 108
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 109
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 110
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 111
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 112
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 113
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 114
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 115
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 116
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 117
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 118
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 119
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 120
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 121
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 122
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 123
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 124
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 125
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 126
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 127
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 128
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 129
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 130
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 131
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 132
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 133
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 134
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 135
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 136
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 116,
+          "thumb_right": 128
+        }
+      ],
+      "reserve": 0,
+      "width": 128
+    },
+    {
+      "maximum": 2,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 29
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 30
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 31
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 32
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 33
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 34
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 35
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 36
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 37
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 38
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 39
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 40
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 41
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 42
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 43
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 44
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 45
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 46
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 47
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 48
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 49
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 50
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 51
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 52
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 53
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 54
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 55
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 56
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 57
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 58
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 59
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 60
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 61
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 62
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 63
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 64
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 65
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 66
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 67
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 68
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 69
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 70
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 71
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 72
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 73
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 74
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 75
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 76
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 77
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 78
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 79
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 80
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 81
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 82
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 83
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 84
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 85
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 86
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 87
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 88
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 89
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 90
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 91
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 92
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 93
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 94
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 95
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 96
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 97
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 98
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 99
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 100
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 101
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 102
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 103
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 104
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 105
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 106
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 107
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 108
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 109
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 110
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 111
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 112
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 113
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 114
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 115
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 116
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 117
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 118
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 119
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 120
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 121
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 122
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 123
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 124
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 125
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 126
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 127
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 128
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 129
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 130
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 131
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 132
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 133
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 134
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 135
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 136
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 58,
+          "thumb_right": 70
+        },
+        {
+          "position": 2,
+          "thumb_left": 116,
+          "thumb_right": 128
+        }
+      ],
+      "reserve": 0,
+      "width": 128
+    },
+    {
+      "maximum": 6,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 24
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 25
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 26
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 27
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 28
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 29
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 30
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 31
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 32
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 33
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 34
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 35
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 36
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 37
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 38
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 39
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 40
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 41
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 42
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 43
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 44
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 45
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 46
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 47
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 48
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 49
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 50
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 51
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 52
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 53
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 54
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 55
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51,
+          "x": 56
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 57
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 58
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 59
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 60
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 61
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 62
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 63
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 64
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 65
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 66
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 67
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 68
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 69
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 70
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 71
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 72
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 73
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 74
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 75
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 76
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 77
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 78
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 79
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 80
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 81
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 82
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 83
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 84
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 85
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 86
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 87
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 88
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89,
+          "x": 89
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 90
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 91
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 92
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 93
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 94
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 95
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 96
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 97
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 98
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 99
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 100
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 101
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 102
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 103
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 104
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108,
+          "x": 105
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 106
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 107
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 108
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 109
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 110
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 111
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 112
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 113
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 114
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 115
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 116
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 117
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 118
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 119
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 120
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 121
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 122
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 123
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 124
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 125
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 126
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 127
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 128
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 129
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 130
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 131
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 132
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 133
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 134
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 135
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 136
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32
+        },
+        {
+          "position": 2,
+          "thumb_left": 39,
+          "thumb_right": 51
+        },
+        {
+          "position": 3,
+          "thumb_left": 58,
+          "thumb_right": 70
+        },
+        {
+          "position": 4,
+          "thumb_left": 77,
+          "thumb_right": 89
+        },
+        {
+          "position": 5,
+          "thumb_left": 96,
+          "thumb_right": 108
+        },
+        {
+          "position": 6,
+          "thumb_left": 116,
+          "thumb_right": 128
+        }
+      ],
+      "reserve": 0,
+      "width": 128
+    },
+    {
+      "maximum": 10,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 18
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 19
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 20
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 21
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 22
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 23
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 24
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 25
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 26
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 27
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 28
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 29
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 30
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 31
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 32
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 33
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 34
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 35
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 36
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 37
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 38
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 39
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 40
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 41
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 42
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 43
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 44
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 45
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 46
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 47
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47,
+          "x": 48
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 49
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 50
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 51
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 52
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 53
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 54
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 55
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 56
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 57
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 58
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 59
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 60
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 61
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 62
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 63
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 64
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 65
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 66
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 67
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 68
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70,
+          "x": 69
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 70
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 71
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 72
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 73
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 74
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 75
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 76
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 77
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 78
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 79
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82,
+          "x": 80
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 81
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 82
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 83
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 84
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 85
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 86
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 87
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 88
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 89
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93,
+          "x": 90
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 91
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 92
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 93
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 94
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 95
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 96
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 97
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 98
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 99
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 100
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105,
+          "x": 101
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 102
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 103
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 104
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 105
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 106
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 107
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 108
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 109
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 110
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116,
+          "x": 111
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 112
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 113
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 114
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 115
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 116
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 117
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 118
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 119
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 120
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 121
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 122
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 123
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 124
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 125
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 126
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 127
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 128
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 129
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 130
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 131
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 132
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 133
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 134
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 135
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128,
+          "x": 136
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36
+        },
+        {
+          "position": 3,
+          "thumb_left": 35,
+          "thumb_right": 47
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59
+        },
+        {
+          "position": 5,
+          "thumb_left": 58,
+          "thumb_right": 70
+        },
+        {
+          "position": 6,
+          "thumb_left": 70,
+          "thumb_right": 82
+        },
+        {
+          "position": 7,
+          "thumb_left": 81,
+          "thumb_right": 93
+        },
+        {
+          "position": 8,
+          "thumb_left": 93,
+          "thumb_right": 105
+        },
+        {
+          "position": 9,
+          "thumb_left": 104,
+          "thumb_right": 116
+        },
+        {
+          "position": 10,
+          "thumb_left": 116,
+          "thumb_right": 128
+        }
+      ],
+      "reserve": 0,
+      "width": 128
+    },
+    {
+      "maximum": 1,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 29
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 30
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 31
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 32
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 33
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 34
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 35
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 36
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 37
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 38
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 39
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 40
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 41
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 42
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 43
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 44
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 45
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 46
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 47
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 48
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 49
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 50
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 51
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 52
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 53
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 54
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 55
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 56
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 57
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 58
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 59
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 60
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 61
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 62
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 63
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 64
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 65
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 66
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 67
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 68
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 69
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 70
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 71
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 72
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 73
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 74
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 75
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 76
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 77
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 78
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 79
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 80
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 81
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 82
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 83
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 84
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 85
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 86
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 87
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 88
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 89
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 90
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 91
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 92
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 93
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 94
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 95
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 96
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 97
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 98
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 99
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 100
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 101
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 102
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 103
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 104
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 105
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 106
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 107
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 108
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 109
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 110
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 111
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 112
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 113
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 114
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 115
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 116
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 117
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 118
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 119
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 120
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 121
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 122
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 123
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 124
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 125
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 126
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 127
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 128
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 129
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 130
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 131
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 132
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 133
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 134
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 135
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 136
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 66,
+          "thumb_right": 78
+        }
+      ],
+      "reserve": 50,
+      "width": 128
+    },
+    {
+      "maximum": 2,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 29
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 30
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 31
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 32
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 33
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 34
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 35
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 36
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 37
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 38
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 39
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 40
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 41
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 42
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 43
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 44
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 45
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 46
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 47
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 48
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 49
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 50
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 51
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 52
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 53
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 54
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 55
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 56
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 57
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 58
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 59
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 60
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 61
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 62
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 63
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 64
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 65
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 66
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 67
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 68
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 69
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 70
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 71
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 72
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 73
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 74
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 75
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 76
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 77
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 78
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 79
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 80
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 81
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 82
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 83
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 84
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 85
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 86
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 87
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 88
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 89
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 90
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 91
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 92
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 93
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 94
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 95
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 96
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 97
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 98
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 99
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 100
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 101
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 102
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 103
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 104
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 105
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 106
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 107
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 108
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 109
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 110
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 111
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 112
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 113
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 114
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 115
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 116
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 117
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 118
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 119
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 120
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 121
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 122
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 123
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 124
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 125
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 126
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 127
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 128
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 129
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 130
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 131
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 132
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 133
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 134
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 135
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 136
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 33,
+          "thumb_right": 45
+        },
+        {
+          "position": 2,
+          "thumb_left": 66,
+          "thumb_right": 78
+        }
+      ],
+      "reserve": 50,
+      "width": 128
+    },
+    {
+      "maximum": 6,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 17
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 18
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 19
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 20
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 21
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 22
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 23
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 24
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23,
+          "x": 25
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 26
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 27
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 28
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 29
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 30
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 31
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 32
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 33
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34,
+          "x": 34
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 35
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 36
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 37
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 38
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 39
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 40
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 41
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 42
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 43
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 44
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 45
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 46
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 47
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 48
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 49
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 50
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 51
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 52
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56,
+          "x": 53
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 54
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 55
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 56
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 57
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 58
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 59
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 60
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 61
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67,
+          "x": 62
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 63
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 64
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 65
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 66
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 67
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 68
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 69
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 70
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 71
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 72
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 73
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 74
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 75
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 76
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 77
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 78
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 79
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 80
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 81
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 82
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 83
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 84
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 85
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 86
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 87
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 88
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 89
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 90
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 91
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 92
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 93
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 94
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 95
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 96
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 97
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 98
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 99
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 100
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 101
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 102
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 103
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 104
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 105
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 106
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 107
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 108
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 109
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 110
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 111
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 112
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 113
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 114
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 115
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 116
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 117
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 118
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 119
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 120
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 121
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 122
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 123
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 124
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 125
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 126
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 127
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 128
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 129
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 130
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 131
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 132
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 133
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 134
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 135
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 136
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 11,
+          "thumb_right": 23
+        },
+        {
+          "position": 2,
+          "thumb_left": 22,
+          "thumb_right": 34
+        },
+        {
+          "position": 3,
+          "thumb_left": 33,
+          "thumb_right": 45
+        },
+        {
+          "position": 4,
+          "thumb_left": 44,
+          "thumb_right": 56
+        },
+        {
+          "position": 5,
+          "thumb_left": 55,
+          "thumb_right": 67
+        },
+        {
+          "position": 6,
+          "thumb_left": 66,
+          "thumb_right": 78
+        }
+      ],
+      "reserve": 50,
+      "width": 128
+    },
+    {
+      "maximum": 10,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 1,
+          "thumb_left": 7,
+          "thumb_right": 19,
+          "x": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 7,
+          "thumb_right": 19,
+          "x": 14
+        },
+        {
+          "position": 1,
+          "thumb_left": 7,
+          "thumb_right": 19,
+          "x": 15
+        },
+        {
+          "position": 1,
+          "thumb_left": 7,
+          "thumb_right": 19,
+          "x": 16
+        },
+        {
+          "position": 1,
+          "thumb_left": 7,
+          "thumb_right": 19,
+          "x": 17
+        },
+        {
+          "position": 1,
+          "thumb_left": 7,
+          "thumb_right": 19,
+          "x": 18
+        },
+        {
+          "position": 2,
+          "thumb_left": 14,
+          "thumb_right": 26,
+          "x": 19
+        },
+        {
+          "position": 2,
+          "thumb_left": 14,
+          "thumb_right": 26,
+          "x": 20
+        },
+        {
+          "position": 2,
+          "thumb_left": 14,
+          "thumb_right": 26,
+          "x": 21
+        },
+        {
+          "position": 2,
+          "thumb_left": 14,
+          "thumb_right": 26,
+          "x": 22
+        },
+        {
+          "position": 2,
+          "thumb_left": 14,
+          "thumb_right": 26,
+          "x": 23
+        },
+        {
+          "position": 2,
+          "thumb_left": 14,
+          "thumb_right": 26,
+          "x": 24
+        },
+        {
+          "position": 3,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 25
+        },
+        {
+          "position": 3,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 26
+        },
+        {
+          "position": 3,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 27
+        },
+        {
+          "position": 3,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 28
+        },
+        {
+          "position": 3,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 29
+        },
+        {
+          "position": 3,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 30
+        },
+        {
+          "position": 4,
+          "thumb_left": 27,
+          "thumb_right": 39,
+          "x": 31
+        },
+        {
+          "position": 4,
+          "thumb_left": 27,
+          "thumb_right": 39,
+          "x": 32
+        },
+        {
+          "position": 4,
+          "thumb_left": 27,
+          "thumb_right": 39,
+          "x": 33
+        },
+        {
+          "position": 4,
+          "thumb_left": 27,
+          "thumb_right": 39,
+          "x": 34
+        },
+        {
+          "position": 4,
+          "thumb_left": 27,
+          "thumb_right": 39,
+          "x": 35
+        },
+        {
+          "position": 4,
+          "thumb_left": 27,
+          "thumb_right": 39,
+          "x": 36
+        },
+        {
+          "position": 5,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 37
+        },
+        {
+          "position": 5,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 38
+        },
+        {
+          "position": 5,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 39
+        },
+        {
+          "position": 5,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 40
+        },
+        {
+          "position": 5,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 41
+        },
+        {
+          "position": 5,
+          "thumb_left": 33,
+          "thumb_right": 45,
+          "x": 42
+        },
+        {
+          "position": 6,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 43
+        },
+        {
+          "position": 6,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 44
+        },
+        {
+          "position": 6,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 45
+        },
+        {
+          "position": 6,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 46
+        },
+        {
+          "position": 6,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 47
+        },
+        {
+          "position": 6,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 48
+        },
+        {
+          "position": 7,
+          "thumb_left": 46,
+          "thumb_right": 58,
+          "x": 49
+        },
+        {
+          "position": 7,
+          "thumb_left": 46,
+          "thumb_right": 58,
+          "x": 50
+        },
+        {
+          "position": 7,
+          "thumb_left": 46,
+          "thumb_right": 58,
+          "x": 51
+        },
+        {
+          "position": 7,
+          "thumb_left": 46,
+          "thumb_right": 58,
+          "x": 52
+        },
+        {
+          "position": 7,
+          "thumb_left": 46,
+          "thumb_right": 58,
+          "x": 53
+        },
+        {
+          "position": 7,
+          "thumb_left": 46,
+          "thumb_right": 58,
+          "x": 54
+        },
+        {
+          "position": 8,
+          "thumb_left": 53,
+          "thumb_right": 65,
+          "x": 55
+        },
+        {
+          "position": 8,
+          "thumb_left": 53,
+          "thumb_right": 65,
+          "x": 56
+        },
+        {
+          "position": 8,
+          "thumb_left": 53,
+          "thumb_right": 65,
+          "x": 57
+        },
+        {
+          "position": 8,
+          "thumb_left": 53,
+          "thumb_right": 65,
+          "x": 58
+        },
+        {
+          "position": 8,
+          "thumb_left": 53,
+          "thumb_right": 65,
+          "x": 59
+        },
+        {
+          "position": 8,
+          "thumb_left": 53,
+          "thumb_right": 65,
+          "x": 60
+        },
+        {
+          "position": 9,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 61
+        },
+        {
+          "position": 9,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 62
+        },
+        {
+          "position": 9,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 63
+        },
+        {
+          "position": 9,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 64
+        },
+        {
+          "position": 9,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 65
+        },
+        {
+          "position": 9,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 66
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 67
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 68
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 69
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 70
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 71
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 72
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 73
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 74
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 75
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 76
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 77
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 78
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 79
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 80
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 81
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 82
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 83
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 84
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 85
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 86
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 87
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 88
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 89
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 90
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 91
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 92
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 93
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 94
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 95
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 96
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 97
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 98
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 99
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 100
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 101
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 102
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 103
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 104
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 105
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 106
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 107
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 108
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 109
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 110
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 111
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 112
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 113
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 114
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 115
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 116
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 117
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 118
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 119
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 120
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 121
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 122
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 123
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 124
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 125
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 126
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 127
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 128
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 129
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 130
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 131
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 132
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 133
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 134
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 135
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78,
+          "x": 136
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 7,
+          "thumb_right": 19
+        },
+        {
+          "position": 2,
+          "thumb_left": 14,
+          "thumb_right": 26
+        },
+        {
+          "position": 3,
+          "thumb_left": 20,
+          "thumb_right": 32
+        },
+        {
+          "position": 4,
+          "thumb_left": 27,
+          "thumb_right": 39
+        },
+        {
+          "position": 5,
+          "thumb_left": 33,
+          "thumb_right": 45
+        },
+        {
+          "position": 6,
+          "thumb_left": 40,
+          "thumb_right": 52
+        },
+        {
+          "position": 7,
+          "thumb_left": 46,
+          "thumb_right": 58
+        },
+        {
+          "position": 8,
+          "thumb_left": 53,
+          "thumb_right": 65
+        },
+        {
+          "position": 9,
+          "thumb_left": 59,
+          "thumb_right": 71
+        },
+        {
+          "position": 10,
+          "thumb_left": 66,
+          "thumb_right": 78
+        }
+      ],
+      "reserve": 50,
+      "width": 128
+    },
+    {
+      "maximum": 1,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 29
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 30
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 31
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 32
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 33
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 34
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 35
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 36
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 37
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 38
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 39
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 40
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 41
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 42
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 43
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 44
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 45
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 46
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 47
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 48
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 49
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 50
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 51
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 52
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 53
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 54
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 55
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 56
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 57
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 58
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 59
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 60
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 61
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 62
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 63
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 64
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 65
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 66
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 67
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 68
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 69
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 70
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 71
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 72
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 73
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 74
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 75
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 76
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 77
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 78
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 79
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 80
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 81
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 82
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 83
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 84
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 85
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 86
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 87
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 88
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 89
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 90
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 91
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 92
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 93
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 94
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 95
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 96
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 97
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 98
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 99
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 100
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 101
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 102
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 103
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 104
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 105
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 106
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 107
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 108
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 109
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 110
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 111
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 112
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 113
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 114
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 115
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 116
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 117
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 118
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 119
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 120
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 121
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 122
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 123
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 124
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 125
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 126
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 127
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 128
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 129
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 130
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 131
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 132
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 133
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 134
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 135
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 136
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 137
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 138
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 139
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 140
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 141
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 142
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 143
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 144
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 145
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 146
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 147
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 148
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 149
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 150
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 151
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 152
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 153
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 154
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 155
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 156
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 157
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 158
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 159
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 160
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 161
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 162
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 163
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 164
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 165
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 166
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 167
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 168
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 169
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 170
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 171
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 172
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 173
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 174
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 175
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 176
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 177
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 178
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 179
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 180
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 181
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 182
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 183
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 184
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 185
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 186
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 187
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 188
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 168,
+          "thumb_right": 180
+        }
+      ],
+      "reserve": 0,
+      "width": 180
+    },
+    {
+      "maximum": 2,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 29
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 30
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 31
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 32
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 33
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 34
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 35
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 36
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 37
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 38
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 39
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 40
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 41
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 42
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 43
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 44
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 45
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 46
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 47
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 48
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 49
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 50
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 51
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 52
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 53
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 54
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 55
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 56
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 57
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 58
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 59
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 60
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 61
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 62
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 63
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 64
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 65
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 66
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 67
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 68
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 69
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 70
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 71
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 72
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 73
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 74
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 75
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 76
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 77
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 78
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 79
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 80
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 81
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 82
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 83
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 84
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 85
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 86
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 87
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 88
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 89
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 90
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 91
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 92
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 93
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 94
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 95
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 96
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 97
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 98
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 99
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 100
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 101
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 102
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 103
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 104
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 105
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 106
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 107
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 108
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 109
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 110
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 111
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 112
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 113
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 114
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 115
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 116
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 117
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 118
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 119
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 120
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 121
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 122
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 123
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 124
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 125
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 126
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 127
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 128
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 129
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 130
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 131
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 132
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 133
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 134
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 135
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 136
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 137
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 138
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 139
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 140
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 141
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 142
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 143
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 144
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 145
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 146
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 147
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 148
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 149
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 150
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 151
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 152
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 153
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 154
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 155
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 156
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 157
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 158
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 159
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 160
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 161
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 162
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 163
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 164
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 165
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 166
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 167
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 168
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 169
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 170
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 171
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 172
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 173
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 174
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 175
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 176
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 177
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 178
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 179
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 180
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 181
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 182
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 183
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 184
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 185
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 186
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 187
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 188
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 84,
+          "thumb_right": 96
+        },
+        {
+          "position": 2,
+          "thumb_left": 168,
+          "thumb_right": 180
+        }
+      ],
+      "reserve": 0,
+      "width": 180
+    },
+    {
+      "maximum": 6,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 29
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 30
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 31
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 32
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 33
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 34
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 35
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 36
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 37
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 38
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 39
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 40
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 41
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 42
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 43
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 44
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 45
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 46
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 47
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 48
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 49
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 50
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 51
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 52
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 53
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40,
+          "x": 54
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 55
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 56
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 57
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 58
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 59
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 60
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 61
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 62
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 63
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 64
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 65
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 66
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 67
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 68
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 69
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 70
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 71
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 72
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 73
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 74
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 75
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 76
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 77
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68,
+          "x": 78
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 79
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 80
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 81
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 82
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 83
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 84
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 85
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 86
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 87
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 88
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 89
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 90
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 91
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 92
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 93
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 94
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 95
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 96
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 97
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 98
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 99
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 100
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 101
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 102
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 103
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 104
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 105
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 106
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 107
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 108
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 109
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 110
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 111
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 112
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 113
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 114
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 115
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 116
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 117
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 118
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 119
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 120
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 121
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 122
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 123
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 124
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 125
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124,
+          "x": 126
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 127
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 128
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 129
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 130
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 131
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 132
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 133
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 134
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 135
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 136
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 137
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 138
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 139
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 140
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 141
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 142
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 143
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 144
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 145
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 146
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 147
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 148
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 149
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152,
+          "x": 150
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 151
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 152
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 153
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 154
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 155
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 156
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 157
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 158
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 159
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 160
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 161
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 162
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 163
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 164
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 165
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 166
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 167
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 168
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 169
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 170
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 171
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 172
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 173
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 174
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 175
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 176
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 177
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 178
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 179
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 180
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 181
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 182
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 183
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 184
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 185
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 186
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 187
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 188
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 28,
+          "thumb_right": 40
+        },
+        {
+          "position": 2,
+          "thumb_left": 56,
+          "thumb_right": 68
+        },
+        {
+          "position": 3,
+          "thumb_left": 84,
+          "thumb_right": 96
+        },
+        {
+          "position": 4,
+          "thumb_left": 112,
+          "thumb_right": 124
+        },
+        {
+          "position": 5,
+          "thumb_left": 140,
+          "thumb_right": 152
+        },
+        {
+          "position": 6,
+          "thumb_left": 168,
+          "thumb_right": 180
+        }
+      ],
+      "reserve": 0,
+      "width": 180
+    },
+    {
+      "maximum": 10,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 23
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 24
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 25
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 26
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 27
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 28
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 29
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 30
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 31
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 32
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 33
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 34
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 35
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 36
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29,
+          "x": 37
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 38
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 39
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 40
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 41
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 42
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 43
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 44
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 45
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 46
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 47
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 48
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 49
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 50
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 51
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46,
+          "x": 52
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 53
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 54
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 55
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 56
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 57
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 58
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 59
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 60
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 61
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 62
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 63
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 64
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 65
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 66
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63,
+          "x": 67
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 68
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 69
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 70
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 71
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 72
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 73
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 74
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 75
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 76
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 77
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 78
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 79
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 80
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 81
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79,
+          "x": 82
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 83
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 84
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 85
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 86
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 87
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 88
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 89
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 90
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 91
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 92
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 93
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 94
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 95
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 96
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 97
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96,
+          "x": 98
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 99
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 100
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 101
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 102
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 103
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 104
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 105
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 106
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 107
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 108
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 109
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 110
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 111
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 112
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113,
+          "x": 113
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 114
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 115
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 116
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 117
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 118
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 119
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 120
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 121
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 122
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 123
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 124
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 125
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 126
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 127
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129,
+          "x": 128
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 129
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 130
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 131
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 132
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 133
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 134
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 135
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 136
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 137
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 138
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 139
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 140
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 141
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 142
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146,
+          "x": 143
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 144
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 145
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 146
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 147
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 148
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 149
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 150
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 151
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 152
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 153
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 154
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 155
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 156
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 157
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163,
+          "x": 158
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 159
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 160
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 161
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 162
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 163
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 164
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 165
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 166
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 167
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 168
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 169
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 170
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 171
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 172
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 173
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 174
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 175
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 176
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 177
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 178
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 179
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 180
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 181
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 182
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 183
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 184
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 185
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 186
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 187
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180,
+          "x": 188
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 17,
+          "thumb_right": 29
+        },
+        {
+          "position": 2,
+          "thumb_left": 34,
+          "thumb_right": 46
+        },
+        {
+          "position": 3,
+          "thumb_left": 51,
+          "thumb_right": 63
+        },
+        {
+          "position": 4,
+          "thumb_left": 67,
+          "thumb_right": 79
+        },
+        {
+          "position": 5,
+          "thumb_left": 84,
+          "thumb_right": 96
+        },
+        {
+          "position": 6,
+          "thumb_left": 101,
+          "thumb_right": 113
+        },
+        {
+          "position": 7,
+          "thumb_left": 117,
+          "thumb_right": 129
+        },
+        {
+          "position": 8,
+          "thumb_left": 134,
+          "thumb_right": 146
+        },
+        {
+          "position": 9,
+          "thumb_left": 151,
+          "thumb_right": 163
+        },
+        {
+          "position": 10,
+          "thumb_left": 168,
+          "thumb_right": 180
+        }
+      ],
+      "reserve": 0,
+      "width": 180
+    },
+    {
+      "maximum": 1,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 29
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 30
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 31
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 32
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 33
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 34
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 35
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 36
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 37
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 38
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 39
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 40
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 41
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 42
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 43
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 44
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 45
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 46
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 47
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 48
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 49
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 50
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 51
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 52
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 53
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 54
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 55
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 56
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 57
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 58
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 59
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 60
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 61
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 62
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 63
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 64
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 65
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 66
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 67
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 68
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 69
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 70
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 71
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 72
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 73
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 74
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 75
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 76
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 77
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 78
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 79
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 80
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 81
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 82
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 83
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 84
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 85
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 86
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 87
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 88
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 89
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 90
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 91
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 92
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 93
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 94
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 95
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 96
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 97
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 98
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 99
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 100
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 101
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 102
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 103
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 104
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 105
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 106
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 107
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 108
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 109
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 110
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 111
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 112
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 113
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 114
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 115
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 116
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 117
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 118
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 119
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 120
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 121
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 122
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 123
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 124
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 125
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 126
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 127
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 128
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 129
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 130
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 131
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 132
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 133
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 134
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 135
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 136
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 137
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 138
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 139
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 140
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 141
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 142
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 143
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 144
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 145
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 146
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 147
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 148
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 149
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 150
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 151
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 152
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 153
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 154
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 155
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 156
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 157
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 158
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 159
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 160
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 161
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 162
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 163
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 164
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 165
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 166
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 167
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 168
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 169
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 170
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 171
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 172
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 173
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 174
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 175
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 176
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 177
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 178
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 179
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 180
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 181
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 182
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 183
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 184
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 185
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 186
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 187
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 188
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 118,
+          "thumb_right": 130
+        }
+      ],
+      "reserve": 50,
+      "width": 180
+    },
+    {
+      "maximum": 2,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 24
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 25
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 26
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 27
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 28
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 29
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 30
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 31
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 32
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 33
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 34
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 35
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 36
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 37
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 38
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 39
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 40
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 41
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 42
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 43
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 44
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 45
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 46
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 47
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 48
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 49
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 50
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 51
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 52
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 53
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 54
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 55
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 56
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 57
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 58
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 59
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 60
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 61
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 62
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 63
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 64
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 65
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 66
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 67
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 68
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 69
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 70
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 71
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 72
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 73
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 74
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 75
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 76
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 77
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 78
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 79
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 80
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 81
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 82
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 83
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 84
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 85
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 86
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 87
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 88
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 89
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 90
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 91
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 92
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 93
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 94
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 95
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 96
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 97
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 98
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 99
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 100
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 101
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 102
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 103
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 104
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 105
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 106
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 107
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 108
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 109
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 110
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 111
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 112
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 113
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 114
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 115
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 116
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 117
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 118
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 119
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 120
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 121
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 122
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 123
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 124
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 125
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 126
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 127
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 128
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 129
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 130
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 131
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 132
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 133
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 134
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 135
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 136
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 137
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 138
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 139
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 140
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 141
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 142
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 143
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 144
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 145
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 146
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 147
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 148
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 149
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 150
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 151
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 152
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 153
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 154
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 155
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 156
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 157
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 158
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 159
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 160
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 161
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 162
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 163
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 164
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 165
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 166
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 167
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 168
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 169
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 170
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 171
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 172
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 173
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 174
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 175
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 176
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 177
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 178
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 179
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 180
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 181
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 182
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 183
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 184
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 185
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 186
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 187
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 188
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 59,
+          "thumb_right": 71
+        },
+        {
+          "position": 2,
+          "thumb_left": 118,
+          "thumb_right": 130
+        }
+      ],
+      "reserve": 50,
+      "width": 180
+    },
+    {
+      "maximum": 6,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 18
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 19
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 20
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 21
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 22
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 23
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 24
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 25
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 26
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 27
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 28
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 29
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 30
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 31
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 32
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 33
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 34
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 35
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 36
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 37
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 38
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 39
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32,
+          "x": 40
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 41
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 42
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 43
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 44
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 45
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 46
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 47
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 48
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 49
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 50
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 51
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 52
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 53
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 54
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 55
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 56
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52,
+          "x": 57
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 58
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 59
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 60
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 61
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 62
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 63
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 64
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 65
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 66
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 67
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 68
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 69
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 70
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 71
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 72
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 73
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 74
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 75
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 76
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 77
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 78
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 79
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 80
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 81
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 82
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 83
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 84
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 85
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 86
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 87
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 88
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 89
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91,
+          "x": 90
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 91
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 92
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 93
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 94
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 95
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 96
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 97
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 98
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 99
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 100
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 101
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 102
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 103
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 104
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 105
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 106
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110,
+          "x": 107
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 108
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 109
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 110
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 111
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 112
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 113
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 114
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 115
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 116
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 117
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 118
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 119
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 120
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 121
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 122
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 123
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 124
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 125
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 126
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 127
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 128
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 129
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 130
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 131
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 132
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 133
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 134
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 135
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 136
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 137
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 138
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 139
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 140
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 141
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 142
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 143
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 144
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 145
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 146
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 147
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 148
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 149
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 150
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 151
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 152
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 153
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 154
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 155
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 156
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 157
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 158
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 159
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 160
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 161
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 162
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 163
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 164
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 165
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 166
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 167
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 168
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 169
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 170
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 171
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 172
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 173
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 174
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 175
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 176
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 177
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 178
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 179
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 180
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 181
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 182
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 183
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 184
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 185
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 186
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 187
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 188
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 20,
+          "thumb_right": 32
+        },
+        {
+          "position": 2,
+          "thumb_left": 40,
+          "thumb_right": 52
+        },
+        {
+          "position": 3,
+          "thumb_left": 59,
+          "thumb_right": 71
+        },
+        {
+          "position": 4,
+          "thumb_left": 79,
+          "thumb_right": 91
+        },
+        {
+          "position": 5,
+          "thumb_left": 98,
+          "thumb_right": 110
+        },
+        {
+          "position": 6,
+          "thumb_left": 118,
+          "thumb_right": 130
+        }
+      ],
+      "reserve": 50,
+      "width": 180
+    },
+    {
+      "maximum": 10,
+      "pointers": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": -1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 0
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 1
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 2
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 3
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 4
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 5
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 6
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 7
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 8
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 9
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 10
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 11
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 12
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 13
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 14
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 15
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 16
+        },
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13,
+          "x": 17
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 18
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 19
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 20
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 21
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 22
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 23
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 24
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 25
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 26
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 27
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24,
+          "x": 28
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 29
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 30
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 31
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 32
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 33
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 34
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 35
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 36
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 37
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36,
+          "x": 38
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 39
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 40
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 41
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 42
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 43
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 44
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 45
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 46
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 47
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 48
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48,
+          "x": 49
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 50
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 51
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 52
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 53
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 54
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 55
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 56
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 57
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 58
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 59
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59,
+          "x": 60
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 61
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 62
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 63
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 64
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 65
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 66
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 67
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 68
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 69
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71,
+          "x": 70
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 71
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 72
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 73
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 74
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 75
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 76
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 77
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 78
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 79
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 80
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83,
+          "x": 81
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 82
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 83
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 84
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 85
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 86
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 87
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 88
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 89
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 90
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 91
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94,
+          "x": 92
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 93
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 94
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 95
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 96
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 97
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 98
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 99
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 100
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 101
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106,
+          "x": 102
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 103
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 104
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 105
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 106
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 107
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 108
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 109
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 110
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 111
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 112
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118,
+          "x": 113
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 114
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 115
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 116
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 117
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 118
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 119
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 120
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 121
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 122
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 123
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 124
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 125
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 126
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 127
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 128
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 129
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 130
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 131
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 132
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 133
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 134
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 135
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 136
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 137
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 138
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 139
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 140
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 141
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 142
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 143
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 144
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 145
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 146
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 147
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 148
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 149
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 150
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 151
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 152
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 153
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 154
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 155
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 156
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 157
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 158
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 159
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 160
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 161
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 162
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 163
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 164
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 165
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 166
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 167
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 168
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 169
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 170
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 171
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 172
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 173
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 174
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 175
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 176
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 177
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 178
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 179
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 180
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 181
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 182
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 183
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 184
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 185
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 186
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 187
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130,
+          "x": 188
+        }
+      ],
+      "positions": [
+        {
+          "position": 0,
+          "thumb_left": 1,
+          "thumb_right": 13
+        },
+        {
+          "position": 1,
+          "thumb_left": 12,
+          "thumb_right": 24
+        },
+        {
+          "position": 2,
+          "thumb_left": 24,
+          "thumb_right": 36
+        },
+        {
+          "position": 3,
+          "thumb_left": 36,
+          "thumb_right": 48
+        },
+        {
+          "position": 4,
+          "thumb_left": 47,
+          "thumb_right": 59
+        },
+        {
+          "position": 5,
+          "thumb_left": 59,
+          "thumb_right": 71
+        },
+        {
+          "position": 6,
+          "thumb_left": 71,
+          "thumb_right": 83
+        },
+        {
+          "position": 7,
+          "thumb_left": 82,
+          "thumb_right": 94
+        },
+        {
+          "position": 8,
+          "thumb_left": 94,
+          "thumb_right": 106
+        },
+        {
+          "position": 9,
+          "thumb_left": 106,
+          "thumb_right": 118
+        },
+        {
+          "position": 10,
+          "thumb_left": 118,
+          "thumb_right": 130
+        }
+      ],
+      "reserve": 50,
+      "width": 180
+    }
+  ],
+  "source": "unicorn/gamemd.exe"
+}

--- a/tools/storage_oracle/launcher_trackbar.meta.json
+++ b/tools/storage_oracle/launcher_trackbar.meta.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "16 supplied geometries; 92 valid positions compared across initialization/405/406; 2736 drag pointer samples, including 2464 in-client samples compared with the admitted rail-click block",
+  "assumptions": [
+    "Client RECT left/top zero; widths 128 and 180, plaque reserve 0 or 50; these cross combinations are arithmetic fixtures, not observed layouts",
+    "Range minimum zero, maximum 1/2/6/10, step one, every valid position; no invalid setter or zero-range claims",
+    "Client x is every integer from -8 through width+8; negative/overshoot samples model capture drag, not admitted rail clicks",
+    "The admitted rail-click block is compared for x in [0,width); y/old-thumb admission, HWND state lookup, Windows pointer retrieval and notifications are outside the fixture",
+    "Registers and stack are reset before each block sequence; native span arithmetic supplies EAX and stack+0x10; original signed integer division executes",
+    "Thumb bounds are read after native stored-offset projection; pixel appearance, repaint timing and whole-dialog equivalence are not established"
+  ],
+  "substitutions": [],
+  "entry_points": {
+    "span": "0x0061DA52",
+    "span_end": "0x0061DA7D",
+    "initial": "0x0061DB40",
+    "initial_end": "0x0061DB52",
+    "set_position": "0x0061E486",
+    "set_position_end": "0x0061E4A8",
+    "set_range": "0x0061E59A",
+    "set_range_end": "0x0061E5C9",
+    "drag": "0x0061DC00",
+    "drag_end": "0x0061DC6D",
+    "rail_click": "0x0061E545",
+    "rail_click_end": "0x0061E598",
+    "thumb_bounds": "0x0061DBB9",
+    "thumb_bounds_end": "0x0061DBD6"
+  },
+  "payload_sha256": "baded0bf62316de51ea5dc85a30ad25f99eb4451bfd0b6d7210b4b0ddce630b3"
+}

--- a/tools/storage_oracle/launcher_trackbar.py
+++ b/tools/storage_oracle/launcher_trackbar.py
@@ -1,0 +1,168 @@
+"""Bounded original launcher trackbar projection and pointer arithmetic.
+
+Active owner 55FC80 supplies D5/proc 55FDB0 at 55FCB3..55FCC1. That proc
+sends ranges 1/2/6/10 (message 406) and positions (405) at 560139..560463.
+Original RT_DIALOG D5/language 1033 declares that trackbar class for controls
+52B/50F/52A (120x13 DLU) and 52F/532/536 (85x13 DLU).
+Common control initialization selects 61D950 for the original ASCII class
+msctls_trackbar32 (835848) at 60FC76..60FCB9; the selected handler is retained
+at 60FF70 behind subclass dispatcher 610CA0. The first three launcher controls
+disable the 50px plaque with 4AC; the three audio controls retain it.
+
+These fixtures execute original interior blocks, not a Windows dialog. Supplied
+client RECTs start at (0, 0), range minimum is zero, step is one and maximum is
+positive. We bypass HWND lookup, OS pointer retrieval, capture admission, paint,
+notifications and audio. Initial/state-set/drag projection is sampled separately;
+only the original instructions produce output coordinates. No code is patched.
+"""
+
+from pathlib import Path
+import struct
+
+from unicorn import Uc, UC_ARCH_X86, UC_MODE_32
+from unicorn.x86_const import (
+    UC_X86_REG_EAX, UC_X86_REG_EBP, UC_X86_REG_EBX,
+    UC_X86_REG_ESI, UC_X86_REG_ESP,
+)
+
+from tools.native_oracle import (
+    STACK_BASE, STACK_SIZE, finish_vectors, load_image, provenance, run_checked,
+)
+
+
+class TrackbarFixture:
+    def __init__(self):
+        self.uc = Uc(UC_ARCH_X86, UC_MODE_32)
+        load_image(self.uc)
+        self.uc.mem_map(STACK_BASE, STACK_SIZE)
+        self.stack = STACK_BASE + STACK_SIZE - 0x1000
+        self.registers = self.uc.context_save()
+
+    def put(self, offset, value):
+        self.uc.mem_write(self.stack + offset, struct.pack("<i", value))
+
+    def get(self, offset):
+        return struct.unpack("<i", self.uc.mem_read(self.stack + offset, 4))[0]
+
+    def prepare(self, width, reserve, maximum):
+        # Restore registers and every stack slot read by the sampled blocks.
+        self.uc.context_restore(self.registers)
+        self.uc.mem_write(self.stack, bytes(0x200))
+        self.uc.reg_write(UC_X86_REG_ESP, self.stack)
+        self.uc.reg_write(UC_X86_REG_EBP, maximum)
+        self.uc.reg_write(UC_X86_REG_ESI, 0)  # Native range minimum.
+        self.put(0x1C, 1)  # Native step.
+        self.put(0x20, reserve)
+        self.put(0xA8, width)  # Client right; client left +0xA0 is zero.
+        # Execute the original usable-span calculation and minimum clamp.
+        run_checked(self.uc, 0x61DA52, 0x61DA7D, count=30,
+                    required_addresses=[0x61DA68, 0x61DA6B])
+
+    def paint_bounds(self):
+        # Project stored +0x18 pixel offset to the native half-open thumb RECT.
+        run_checked(self.uc, 0x61DBB9, 0x61DBD6, count=20,
+                    required_addresses=[0x61DBC4, 0x61DBCF])
+        return self.get(0x84), self.get(0x28)
+
+    def position(self, width, reserve, maximum, position, path):
+        self.prepare(width, reserve, maximum)
+        self.uc.reg_write(UC_X86_REG_EBX, position)
+        if path == "set_position":
+            self.put(0x160, position)  # 405 lParam; EAX retains usable span.
+            run_checked(self.uc, 0x61E486, 0x61E4A8, count=30,
+                        required_addresses=[0x61E497, 0x61E499, 0x61E49D])
+        elif path == "set_range":
+            self.put(0x160, maximum << 16)  # 406 MAKELONG(0, maximum).
+            run_checked(self.uc, 0x61E59A, 0x61E5C9, count=30,
+                        required_addresses=[0x61E5AC, 0x61E5BA, 0x61E5BE])
+        elif path == "initial":
+            # EBX models the position returned by original TBM_GETPOS;
+            # ESI/EBP model the preceding native minimum/range queries.
+            run_checked(self.uc, 0x61DB40, 0x61DB52, count=20,
+                        required_addresses=[0x61DB46, 0x61DB4A, 0x61DB4E])
+        else:
+            raise ValueError(path)
+        return self.paint_bounds()
+
+    def pointer(self, width, reserve, maximum, x, path):
+        self.prepare(width, reserve, maximum)
+        if path == "drag":
+            self.put(0x64, x)  # Client x after GetCursorPos/ScreenToClient.
+            run_checked(self.uc, 0x61DC00, 0x61DC6D, count=70,
+                        required_addresses=[0x61DC2B, 0x61DC2F,
+                                            0x61DC54, 0x61DC58])
+        elif path == "rail_click":
+            # EAX is client x after LPARAM unpacking and y/thumb admission.
+            # Only in-client nonnegative x values take this comparison path.
+            self.uc.reg_write(UC_X86_REG_EAX, x)
+            run_checked(self.uc, 0x61E545, 0x61E598, count=70,
+                        required_addresses=[0x61E56C, 0x61E570,
+                                            0x61E58E, 0x61E592])
+        else:
+            raise ValueError(path)
+        value = self.uc.reg_read(UC_X86_REG_EBX)
+        return (value, *self.paint_bounds())
+
+
+def generate():
+    fixture = TrackbarFixture()
+    geometries = []
+    for width in (128, 180):
+        for reserve in (0, 50):
+            for maximum in (1, 2, 6, 10):
+                positions = []
+                for position in range(maximum + 1):
+                    bounds = fixture.position(width, reserve, maximum, position,
+                                              "set_position")
+                    for path in ("set_range", "initial"):
+                        other = fixture.position(width, reserve, maximum,
+                                                 position, path)
+                        if other != bounds:
+                            raise RuntimeError(f"Native {path} disagrees: "
+                                               f"{width, reserve, maximum, position}")
+                    positions.append({"position": position,
+                                      "thumb_left": bounds[0],
+                                      "thumb_right": bounds[1]})
+                pointers = []
+                for x in range(-8, width + 9):
+                    value, left, right = fixture.pointer(width, reserve, maximum,
+                                                        x, "drag")
+                    if 0 <= x < width:
+                        click = fixture.pointer(width, reserve, maximum,
+                                                x, "rail_click")
+                        if click != (value, left, right):
+                            raise RuntimeError(f"Native click/drag disagree: "
+                                               f"{width, reserve, maximum, x}")
+                    pointers.append({"x": x, "position": value,
+                                     "thumb_left": left, "thumb_right": right})
+                geometries.append({"width": width, "reserve": reserve,
+                                   "maximum": maximum, "positions": positions,
+                                   "pointers": pointers})
+    return {"source": "unicorn/gamemd.exe", "geometries": geometries}
+
+
+if __name__ == "__main__":
+    finish_vectors(generate, Path(__file__).with_suffix(".json"),
+                   provenance=lambda: provenance(
+        scope=("16 supplied geometries; 92 valid positions compared across "
+               "initialization/405/406; 2736 drag pointer samples, including "
+               "2464 in-client samples compared with the admitted rail-click block"),
+        assumptions=[
+            "Client RECT left/top zero; widths 128 and 180, plaque reserve 0 or 50; these cross combinations are arithmetic fixtures, not observed layouts",
+            "Range minimum zero, maximum 1/2/6/10, step one, every valid position; no invalid setter or zero-range claims",
+            "Client x is every integer from -8 through width+8; negative/overshoot samples model capture drag, not admitted rail clicks",
+            "The admitted rail-click block is compared for x in [0,width); y/old-thumb admission, HWND state lookup, Windows pointer retrieval and notifications are outside the fixture",
+            "Registers and stack are reset before each block sequence; native span arithmetic supplies EAX and stack+0x10; original signed integer division executes",
+            "Thumb bounds are read after native stored-offset projection; pixel appearance, repaint timing and whole-dialog equivalence are not established",
+        ],
+        substitutions=[],
+        entry_points={
+            "span": 0x61DA52, "span_end": 0x61DA7D,
+            "initial": 0x61DB40, "initial_end": 0x61DB52,
+            "set_position": 0x61E486, "set_position_end": 0x61E4A8,
+            "set_range": 0x61E59A, "set_range_end": 0x61E5C9,
+            "drag": 0x61DC00, "drag_end": 0x61DC6D,
+            "rail_click": 0x61E545, "rail_click_end": 0x61E598,
+            "thumb_bounds": 0x61DBB9, "thumb_bounds_end": 0x61DBD6,
+        },
+    ))

--- a/tools/storage_oracle/shell_text_lines.json
+++ b/tools/storage_oracle/shell_text_lines.json
@@ -1,0 +1,1335 @@
+{
+  "cases": [
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 1,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 2,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 3,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        }
+      ],
+      "text": "A\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 4,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        },
+        {
+          "x": 11,
+          "y": 64
+        }
+      ],
+      "text": "A\nA\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 1,
+      "line_count": 1,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 1,
+      "line_count": 2,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 1,
+      "line_count": 3,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 1,
+      "line_count": 4,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 16,
+      "line_count": 1,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 16,
+      "line_count": 2,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 16,
+      "line_count": 3,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 16,
+      "line_count": 4,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 17,
+      "line_count": 1,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 17,
+      "line_count": 2,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 17,
+      "line_count": 3,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 17,
+      "line_count": 4,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A\nA\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 18,
+      "line_count": 1,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 18,
+      "line_count": 2,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 18,
+      "line_count": 3,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 18,
+      "line_count": 4,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A\nA\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 1,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 2,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 3,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 4,
+      "mode": "newline",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A\nA\nA\nA",
+      "width": 100
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 1,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 2,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 3,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        }
+      ],
+      "text": "A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 4,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        },
+        {
+          "x": 11,
+          "y": 64
+        }
+      ],
+      "text": "A A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 1,
+      "line_count": 1,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 1,
+      "line_count": 2,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 1,
+      "line_count": 3,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 1,
+      "line_count": 4,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 16,
+      "line_count": 1,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 16,
+      "line_count": 2,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 16,
+      "line_count": 3,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 16,
+      "line_count": 4,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 17,
+      "line_count": 1,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 17,
+      "line_count": 2,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 17,
+      "line_count": 3,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 17,
+      "line_count": 4,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 18,
+      "line_count": 1,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 18,
+      "line_count": 2,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 18,
+      "line_count": 3,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 18,
+      "line_count": 4,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 1,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        }
+      ],
+      "text": "A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 2,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 3,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 4,
+      "mode": "wrap",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        }
+      ],
+      "text": "A A A A",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "word_suffix",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        },
+        {
+          "x": 17,
+          "y": 47
+        }
+      ],
+      "text": "AA AAAA",
+      "width": 18
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 0,
+      "mode": "word_suffix",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        }
+      ],
+      "text": "AA AAAA",
+      "width": 18
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "word_suffix",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        },
+        {
+          "x": 23,
+          "y": 30
+        },
+        {
+          "x": 29,
+          "y": 30
+        }
+      ],
+      "text": "AA AAAA",
+      "width": 24
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 0,
+      "mode": "word_suffix",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        },
+        {
+          "x": 23,
+          "y": 30
+        },
+        {
+          "x": 29,
+          "y": 30
+        }
+      ],
+      "text": "AA AAAA",
+      "width": 24
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "word_suffix",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        },
+        {
+          "x": 23,
+          "y": 30
+        },
+        {
+          "x": 29,
+          "y": 30
+        }
+      ],
+      "text": "AA AAAA",
+      "width": 30
+    },
+    {
+      "cell_height": 17,
+      "height": 34,
+      "line_count": 0,
+      "mode": "word_suffix",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        },
+        {
+          "x": 23,
+          "y": 30
+        },
+        {
+          "x": 29,
+          "y": 30
+        }
+      ],
+      "text": "AA AAAA",
+      "width": 30
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        }
+      ],
+      "text": "AA",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        }
+      ],
+      "text": "AA",
+      "width": 12
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        }
+      ],
+      "text": "AA",
+      "width": 18
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        },
+        {
+          "x": 17,
+          "y": 47
+        }
+      ],
+      "text": "AAA",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        }
+      ],
+      "text": "AAA",
+      "width": 12
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 23,
+          "y": 13
+        }
+      ],
+      "text": "AAA",
+      "width": 18
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        },
+        {
+          "x": 11,
+          "y": 64
+        },
+        {
+          "x": 17,
+          "y": 64
+        }
+      ],
+      "text": "AAAA",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        },
+        {
+          "x": 23,
+          "y": 30
+        }
+      ],
+      "text": "AAAA",
+      "width": 12
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        }
+      ],
+      "text": "AAAA",
+      "width": 18
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        },
+        {
+          "x": 11,
+          "y": 64
+        },
+        {
+          "x": 11,
+          "y": 81
+        },
+        {
+          "x": 11,
+          "y": 98
+        },
+        {
+          "x": 17,
+          "y": 98
+        }
+      ],
+      "text": "AAAAAA",
+      "width": 6
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        },
+        {
+          "x": 11,
+          "y": 47
+        },
+        {
+          "x": 17,
+          "y": 47
+        },
+        {
+          "x": 23,
+          "y": 47
+        }
+      ],
+      "text": "AAAAAA",
+      "width": 12
+    },
+    {
+      "cell_height": 17,
+      "height": 0,
+      "line_count": 0,
+      "mode": "hard_cut",
+      "result": 1,
+      "submissions": [
+        {
+          "x": 11,
+          "y": 13
+        },
+        {
+          "x": 17,
+          "y": 13
+        },
+        {
+          "x": 11,
+          "y": 30
+        },
+        {
+          "x": 17,
+          "y": 30
+        },
+        {
+          "x": 23,
+          "y": 30
+        },
+        {
+          "x": 29,
+          "y": 30
+        }
+      ],
+      "text": "AAAAAA",
+      "width": 18
+    }
+  ],
+  "source": "unicorn/gamemd.exe"
+}

--- a/tools/storage_oracle/shell_text_lines.meta.json
+++ b/tools/storage_oracle/shell_text_lines.meta.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "66 original 434CD0 fixtures: 48 line-admission, six saved-space word-suffix rewinds and 12 no-space hard cuts",
+  "assumptions": [
+    "Supplied font cell height17, A glyph width6, space width3, spacing0, color1; original 4346C0 glyph lookup and 434110 x-position setter execute",
+    "One through four A lines, either explicit LF with width100 or space-delimited words wrapping at width6; origin11,13",
+    "Six additional AA AAAA word-suffix cases use widths18/24/30 and heights0/34; line_count0 means input line count is unspecified, and submissions are the native result",
+    "Twelve no-space cases use AA/AAA/AAAA/AAAAAA, widths6/12/18 and height0; hard-cut instructions are required only when supplied text exceeds width",
+    "Height0 is unbounded; ordinary small control heights1/16/17/18/34; alignment and reveal inputs zero",
+    "Complete 434CD0 body executes from entry to RET0x28, with fresh emulator and explicit required lookup/setter/raster and newline/wrap tail visits",
+    "Captured glyph-call positions establish line admission only, not per-pixel scissor, raster appearance, actual font data or general word wrapping"
+  ],
+  "substitutions": [
+    "4348F0 surface lock/setup and 434990 unlock/cleanup return without a real surface; layout fields are supplied separately",
+    "434120 glyph raster is observed as character/x/y arguments and returns x+6; no raster pixels are produced"
+  ],
+  "entry_points": {
+    "draw_text": "0x00434CD0",
+    "shell_caller": "0x0062102E",
+    "newline_height": "0x00434EC2",
+    "wrap_height": "0x00435112"
+  },
+  "payload_sha256": "1919bbbf3e89393e7abf4a34b45afced2d8cfe91fdc30573723db1e7956ffacc"
+}

--- a/tools/storage_oracle/shell_text_lines.py
+++ b/tools/storage_oracle/shell_text_lines.py
@@ -1,0 +1,137 @@
+"""Original 434CD0 line submission with supplied font and observed glyph calls.
+
+Shell wrapper 620F60 computes RECT width/height at 620FC5..620FDA and passes
+them directly to 434CD0 at 62102E. The body submits a line before consulting
+height at its newline (434EC2..434ED7) or wrap (435112..435127) tail. These
+fixtures execute that complete body, including its original glyph lookup and
+horizontal-position setter, but replace surface lock/unlock and glyph raster.
+They establish glyph submission, not clipped raster pixels or complete layout.
+"""
+
+from pathlib import Path
+import struct
+
+from unicorn import Uc, UC_ARCH_X86, UC_MODE_32, UC_HOOK_CODE
+from unicorn.x86_const import UC_X86_REG_EAX, UC_X86_REG_EIP, UC_X86_REG_ESP
+
+from tools.native_oracle import (
+    RET_MAGIC, SCRATCH, SCRATCH_SIZE, STACK_BASE, STACK_SIZE,
+    finish_vectors, load_image, provenance, run_checked,
+)
+
+
+def native_case(mode, height, line_count, *, text=None, width=None):
+    uc = Uc(UC_ARCH_X86, UC_MODE_32)
+    load_image(uc)
+    uc.mem_map(STACK_BASE, STACK_SIZE)
+    uc.mem_map(SCRATCH, SCRATCH_SIZE)
+    uc.mem_map(RET_MAGIC, 0x1000)
+    font, font_data, indices = SCRATCH, SCRATCH + 0x100, SCRATCH + 0x200
+    glyph, text_address = SCRATCH + 0x400, SCRATCH + 0x500
+
+    def put(address, value):
+        uc.mem_write(address, struct.pack("<I", value))
+
+    put(font + 4, font_data)
+    put(font + 0x1C, 17)
+    put(font + 0x24, 1)  # Ordinary non-sentinel text color.
+    put(font_data + 0x14, 8)  # Glyph record size.
+    put(font_data + 0x18, indices)
+    put(font_data + 0x1C, glyph)
+    uc.mem_write(indices + ord("A") * 2, struct.pack("<H", 1))
+    uc.mem_write(indices + ord(" ") * 2, struct.pack("<H", 2))
+    uc.mem_write(glyph, bytes([6]))  # Glyph width; font spacing remains zero.
+    uc.mem_write(glyph + 8, bytes([3]))  # Ordinary separating space.
+    if text is None:
+        text = ("\n" if mode == "newline" else " ").join(["A"] * line_count)
+    uc.mem_write(text_address, (text + "\0").encode("utf-16-le"))
+    if width is None:
+        width = 100 if mode == "newline" else 6
+    stack = STACK_BASE + STACK_SIZE - 0x1000
+    args = [font, SCRATCH + 0x800, text_address, 11, 13, width, height, 0, 0, 0]
+    uc.mem_write(stack, struct.pack("<11I", RET_MAGIC, *args))
+    uc.reg_write(UC_X86_REG_ESP, stack)
+    submissions = []
+
+    def substitute(_uc, address, _size, _data):
+        if address not in (0x4348F0, 0x434990, 0x434120):
+            return
+        sp = uc.reg_read(UC_X86_REG_ESP)
+        ret = struct.unpack("<I", uc.mem_read(sp, 4))[0]
+        if address == 0x434120:
+            char, x, y, _color = struct.unpack("<4I", uc.mem_read(sp + 4, 16))
+            if char & 0xFFFF != ord("A"):
+                raise RuntimeError(f"Unexpected submitted character: {char:#x}")
+            submissions.append({"x": x, "y": y})
+            uc.reg_write(UC_X86_REG_EAX, x + 6)
+            argument_bytes = 16
+        else:
+            # Surface setup/teardown have no layout return value in this body.
+            uc.reg_write(UC_X86_REG_EAX, 0)
+            argument_bytes = 4
+        uc.reg_write(UC_X86_REG_ESP, sp + 4 + argument_bytes)
+        uc.reg_write(UC_X86_REG_EIP, ret)
+
+    hook = uc.hook_add(UC_HOOK_CODE, substitute)
+    required = [0x4346C0, 0x434110]
+    if mode == "hard_cut":
+        if len(text) * 6 > width:
+            # No-space overflow with more than one measured glyph takes the
+            # original scan-pointer-minus-one-code-unit path. A one-glyph-wide
+            # first cut may submit no glyph, so do not require its raster call.
+            required.extend([0x434F6F, 0x434F75, 0x434F78, 0x435112])
+        required.append(0x4352B5)
+    elif mode == "word_suffix":
+        # Original saved-space rewind and skip/restart must actually execute.
+        required.extend([0x434F60, 0x434F64, 0x435103, 0x43512D,
+                         0x435112, 0x4350DC])
+    elif line_count > 1:
+        required.append(0x434EC2 if mode == "newline" else 0x435112)
+        required.append(0x434EA1 if mode == "newline" else 0x4350DC)
+    else:
+        required.append(0x4352B5)
+    try:
+        run_checked(uc, 0x434CD0, RET_MAGIC, count=5000,
+                    required_addresses=required)
+    finally:
+        uc.hook_del(hook)
+    return {"mode": mode, "cell_height": 17, "height": height,
+            "line_count": line_count, "width": width, "text": text,
+            "submissions": submissions, "result": uc.reg_read(UC_X86_REG_EAX) & 0xFF}
+
+
+def generate():
+    cases = [
+        native_case(mode, height, lines)
+        for mode in ("newline", "wrap")
+        for height in (0, 1, 16, 17, 18, 34)
+        for lines in range(1, 5)
+    ]
+    cases.extend(native_case("word_suffix", height, 0, text="AA AAAA", width=width)
+                 for width in (18, 24, 30) for height in (0, 34))
+    cases.extend(native_case("hard_cut", 0, 0, text=text, width=width)
+                 for text in ("AA", "AAA", "AAAA", "AAAAAA")
+                 for width in (6, 12, 18))
+    return {"source": "unicorn/gamemd.exe", "cases": cases}
+
+
+if __name__ == "__main__":
+    finish_vectors(generate, Path(__file__).with_suffix(".json"),
+                   provenance=lambda: provenance(
+        scope="66 original 434CD0 fixtures: 48 line-admission, six saved-space word-suffix rewinds and 12 no-space hard cuts",
+        assumptions=[
+            "Supplied font cell height17, A glyph width6, space width3, spacing0, color1; original 4346C0 glyph lookup and 434110 x-position setter execute",
+            "One through four A lines, either explicit LF with width100 or space-delimited words wrapping at width6; origin11,13",
+            "Six additional AA AAAA word-suffix cases use widths18/24/30 and heights0/34; line_count0 means input line count is unspecified, and submissions are the native result",
+            "Twelve no-space cases use AA/AAA/AAAA/AAAAAA, widths6/12/18 and height0; hard-cut instructions are required only when supplied text exceeds width",
+            "Height0 is unbounded; ordinary small control heights1/16/17/18/34; alignment and reveal inputs zero",
+            "Complete 434CD0 body executes from entry to RET0x28, with fresh emulator and explicit required lookup/setter/raster and newline/wrap tail visits",
+            "Captured glyph-call positions establish line admission only, not per-pixel scissor, raster appearance, actual font data or general word wrapping",
+        ],
+        substitutions=[
+            "4348F0 surface lock/setup and 434990 unlock/cleanup return without a real surface; layout fields are supplied separately",
+            "434120 glyph raster is observed as character/x/y arguments and returns x+6; no raster pixels are produced",
+        ],
+        entry_points={"draw_text": 0x434CD0, "shell_caller": 0x62102E,
+                      "newline_height": 0x434EC2, "wrap_height": 0x435112},
+    ))


### PR DESCRIPTION
The launcher Options card clipped settings and collapsed its right column on the 800x600 shell at 125% display scale. Render the D5 parent with retail physical geometry, bitmap text, artwork and mouse controls while retaining the existing settings/event owner and fallback transaction. Share control painting and correct native slider projection, focus-loss cancellation, partial-line admission and wrapped-text scan/emission boundaries.

Validation: 8,708 library tests passed (121 ignored); Clippy and release build passed. Original-instruction comparisons cover 16 slider geometries and 66 text cases. Production checks cover slider endpoints, checkboxes, resolution selection, persistence and return paths; the final release retains the exact previous Skirmish frame hash. Fresh independent read-only review passed, and three independently confirmed Ghidra comments were saved and read back.

Evidence and coverage limits are in docs/research/skirmish-ui/2026-09-12-launcher-options-shell.md. Keyboard/Network child screens, complete transitions, other shell families and native pixel comparison remain open.
